### PR TITLE
update go version to `1.23.4`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.3-alpine  AS builder
+FROM golang:1.23.4-alpine  AS builder
 RUN apk add --no-cache make
 
 # swagger docs generation will fail if cgo is used

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/greenbone/opensight-notification-service
 
-go 1.23.3
+go 1.23.4
 
 require (
 	github.com/gin-contrib/cors v1.7.3


### PR DESCRIPTION
## What

update go version to `1.23.4`

## Why

We want to be up to date and required by latest versions of some dependencies.

## References

Failing dependabot PR: #56 


