### PR TITLE
change: restrict origins for CSRF protection

### DIFF
--- a/cmd/notification-service/main.go
+++ b/cmd/notification-service/main.go
@@ -88,7 +88,7 @@ func run(config config.Config) error {
 	notificationService := notificationservice.NewNotificationService(notificationRepository)
 	healthService := healthservice.NewHealthService(pgClient)
 
-	gin := web.NewWebEngine()
+	gin := web.NewWebEngine(config.Http)
 	rootRouter := gin.Group("/")
 	notificationServiceRouter := gin.Group("/api/notification-service")
 	docsRouter := gin.Group("/docs/notification-service")

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -15,6 +15,7 @@ services:
       DB_NAME: notification_service
       DB_SSL_MODE: disable
       LOG_LEVEL: debug
+      # HTTP_ALLOWED_ORIGINS: <frontend address> # uncomment and set frontend address for access from frontend
     ports:
       - 8085:8085
     networks:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,10 +19,11 @@ type Config struct {
 }
 
 type Http struct {
-	Port         int           `validate:"required,min=1,max=65535" envconfig:"PORT" default:"8085"`
-	ReadTimeout  time.Duration `envconfig:"READ_TIMEOUT" default:"10s"`
-	WriteTimeout time.Duration `envconfig:"WRITE_TIMEOUT" default:"60s"`
-	IdleTimeout  time.Duration `envconfig:"IDLE_TIMEOUT" default:"60s"`
+	Port           int           `validate:"required,min=1,max=65535" envconfig:"PORT" default:"8085"`
+	ReadTimeout    time.Duration `envconfig:"READ_TIMEOUT" default:"10s"`
+	WriteTimeout   time.Duration `envconfig:"WRITE_TIMEOUT" default:"60s"`
+	IdleTimeout    time.Duration `envconfig:"IDLE_TIMEOUT" default:"60s"`
+	AllowedOrigins []string      `envconfig:"ALLOWED_ORIGINS" default:"https://opensight-lookout.greenbone.io"`
 }
 
 type Database struct {

--- a/pkg/web/middleware/cors.go
+++ b/pkg/web/middleware/cors.go
@@ -11,12 +11,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetCors() gin.HandlerFunc {
+func CORS(allowedOrigins []string) gin.HandlerFunc {
 	CORSHandler := cors.New(cors.Config{
-		AllowAllOrigins:  true, // TODO: should be more restrictive
+		AllowOrigins:     allowedOrigins,
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
-		AllowCredentials: false,
+		AllowCredentials: false, // setting does not cover use of JWT tokens in Authorization header -> not applicable
 		MaxAge:           12 * time.Hour,
 	})
 

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -7,15 +7,16 @@ package web
 import (
 	"github.com/gin-contrib/logger"
 	"github.com/gin-gonic/gin"
+	"github.com/greenbone/opensight-notification-service/pkg/config"
 	"github.com/greenbone/opensight-notification-service/pkg/web/middleware"
 )
 
-func NewWebEngine() *gin.Engine {
+func NewWebEngine(httpConfig config.Http) *gin.Engine {
 	ginWebEngine := gin.New()
 	ginWebEngine.Use(
 		logger.SetLogger(),
 		gin.Recovery(),
-		middleware.GetCors(),
+		middleware.CORS(httpConfig.AllowedOrigins),
 		middleware.ErrorHandler(gin.ErrorTypeAny),
 	)
 	return ginWebEngine


### PR DESCRIPTION
## What

restrict origins for CSRF protection

## Why

We want to prevent that malicious websites can do a cross site request forgery attack (CSRF) on our service. I.e. a malicious website trying to use authentication from a trusted website, but executing arbitrary api calls with the gained credentials.

*Note*: checking the content type in the middleware does not add any benefit against CSRF, as a 'simple' request as well as a preflight request from the wrong origin is already rejected by the CORS middleware.

## References

Jira Ticket: [VTI-522 - Implement CSRF protection](https://jira.greenbone.net/browse/VTI-522)


