### PR TITLE
ci: configure dependabot for docker base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "04:00"
+      day: "monday"


### PR DESCRIPTION
## What

ci: configure dependabot for docker base image

## Why

Keep Docker base image up to date.


