### PR TITLE
change: sort origin options alphabetically, highlight special origin `All`

### DIFF
--- a/pkg/models/rule.go
+++ b/pkg/models/rule.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	OriginAllServiceID = "global"
-	OriginAllName      = "All"
+	OriginAllName      = "--- ALL ---" // should stand out and be alphabetically first
 	// special origin which matches all origins in a notification
 	OriginAllClass = "/global/all"
 )

--- a/pkg/repository/originrepository/originRepository.go
+++ b/pkg/repository/originrepository/originRepository.go
@@ -82,7 +82,7 @@ func (r *OriginRepository) UpsertOrigins(ctx context.Context, serviceID string, 
 }
 
 // ListOrigins returns all origins in the database.
-// The origins are ordered by serviceID and name.
+// The origins are ordered by name with serviceID as tie breaker.
 func (r *OriginRepository) ListOrigins(ctx context.Context) ([]entities.Origin, error) {
 	var originRows []originRow
 	err := r.client.SelectContext(ctx, &originRows, listOriginsQuery)

--- a/pkg/repository/originrepository/origin_db_models.go
+++ b/pkg/repository/originrepository/origin_db_models.go
@@ -10,7 +10,7 @@ const (
 	originsTable       = "notification_service.origins"
 	deleteOriginsQuery = `DELETE FROM ` + originsTable + ` WHERE service_id = $1`
 	createOriginsQuery = `INSERT INTO ` + originsTable + ` (name, class, service_id) VALUES (:name, :class, :service_id)`
-	listOriginsQuery   = `SELECT * FROM ` + originsTable + ` ORDER BY service_id, name`
+	listOriginsQuery   = `SELECT * FROM ` + originsTable + ` ORDER BY name, service_id COLLATE "C"` // ensure deterministic sort order accross locales
 )
 
 type originRow struct {


### PR DESCRIPTION
## What

change: sort origin options alphabetically, highlight special origin `All`

## Why

The user is not so interested which sub service the origin comes from. So alphabetical order is easier to grasp. Also we should highlight the special origin value `All` for the alert rule filter, so that it stands out from the normal origins.

## References

ARTOSI-266


