### PR TITLE
Add osi.user: Allow only PUT OPTIONS /notifications

### DIFF
--- a/pkg/web/iam/roles.go
+++ b/pkg/web/iam/roles.go
@@ -6,6 +6,7 @@ package iam
 
 const (
 	User         = "user"
+	OsiUser      = "osi.user"
 	Admin        = "admin"
 	Notification = "opensight_notification_role"
 )

--- a/pkg/web/notificationcontroller/notificationController.go
+++ b/pkg/web/notificationcontroller/notificationController.go
@@ -35,7 +35,7 @@ func AddNotificationController(
 
 	groupPath := "/notifications"
 
-	router.Group(groupPath).Use(middleware.AuthorizeRoles(auth, iam.User)...).
+	router.Group(groupPath).Use(middleware.AuthorizeRoles(auth, iam.User, iam.OsiUser)...).
 		PUT("", ctrl.ListNotifications).
 		GET("/options", ctrl.GetOptions)
 	// only to be used by other backend services

--- a/pkg/web/notificationcontroller/notificationController_test.go
+++ b/pkg/web/notificationcontroller/notificationController_test.go
@@ -65,6 +65,9 @@ func TestRuleController_Role(t *testing.T) {
 		"Create notification is forbidden for role user": {
 			role: iam.User,
 		},
+		"Create notification is forbidden for role osi.user": {
+			role: iam.OsiUser,
+		},
 		"Create notification is forbidden for role admin": {
 			role: iam.Admin,
 		},
@@ -171,6 +174,58 @@ func TestListNotifications(t *testing.T) {
 				StatusCode(tt.want.responseCode).
 				GetJsonBodyObject(&gotResponse)
 			require.Equal(t, tt.want.responseParsed, gotResponse)
+		})
+	}
+}
+
+func TestListNotifications_Role(t *testing.T) {
+	t.Parallel()
+
+	resultSelector := query.ResultSelector{
+		Filter: &filter.Request{Operator: filter.LogicOperatorAnd},
+		Paging: &paging.Request{PageSize: 10},
+		Sorting: &sorting.Request{
+			SortColumn:    dtos.OccurrenceFieldName,
+			SortDirection: sorting.DirectionAscending,
+		},
+	}
+
+	tests := map[string]struct {
+		role       string
+		wantStatus int
+	}{
+		"Create notification is allowed for role user": {
+			role:       iam.User,
+			wantStatus: http.StatusOK,
+		},
+		"Create notification is allowed for role osi.user": {
+			role:       iam.OsiUser,
+			wantStatus: http.StatusOK,
+		},
+		"Create notification is allowed for role admin": {
+			role:       iam.Admin,
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			router, mockNotificationService := setup(t)
+
+			if tt.wantStatus == http.StatusOK {
+				mockNotificationService.EXPECT().ListNotifications(mock.Anything, resultSelector).
+					Return([]models.Notification{}, uint64(0), nil).
+					Once()
+			}
+
+			httpassert.New(t, router).
+				Put("/notifications").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(tt.role)).
+				JsonContentObject(resultSelector).
+				Expect().
+				StatusCode(tt.wantStatus)
 		})
 	}
 }

--- a/pkg/web/notificationcontroller/notificationController_test.go
+++ b/pkg/web/notificationcontroller/notificationController_test.go
@@ -185,15 +185,15 @@ func TestListNotifications_Role(t *testing.T) {
 		role       string
 		wantStatus int
 	}{
-		"Create notification is allowed for role user": {
+		"List notification is allowed for role user": {
 			role:       iam.User,
 			wantStatus: http.StatusOK,
 		},
-		"Create notification is allowed for role osi.user": {
+		"List notification is allowed for role osi.user": {
 			role:       iam.OsiUser,
 			wantStatus: http.StatusOK,
 		},
-		"Create notification is forbidden for role admin": {
+		"List notification is forbidden for role admin": {
 			role:       iam.Admin,
 			wantStatus: http.StatusForbidden,
 		},
@@ -214,7 +214,7 @@ func TestListNotifications_Role(t *testing.T) {
 			httpassert.New(t, router).
 				Put("/notifications").
 				AuthJwt(integrationTests.CreateJwtTokenWithRole(tt.role)).
-				JsonContentObject(query.ResultSelector{}).
+				Content("{}").
 				Expect().
 				StatusCode(tt.wantStatus)
 		})

--- a/pkg/web/notificationcontroller/notificationController_test.go
+++ b/pkg/web/notificationcontroller/notificationController_test.go
@@ -181,15 +181,6 @@ func TestListNotifications(t *testing.T) {
 func TestListNotifications_Role(t *testing.T) {
 	t.Parallel()
 
-	resultSelector := query.ResultSelector{
-		Filter: &filter.Request{Operator: filter.LogicOperatorAnd},
-		Paging: &paging.Request{PageSize: 10},
-		Sorting: &sorting.Request{
-			SortColumn:    dtos.OccurrenceFieldName,
-			SortDirection: sorting.DirectionAscending,
-		},
-	}
-
 	tests := map[string]struct {
 		role       string
 		wantStatus int
@@ -202,7 +193,7 @@ func TestListNotifications_Role(t *testing.T) {
 			role:       iam.OsiUser,
 			wantStatus: http.StatusOK,
 		},
-		"Create notification is allowed for role admin": {
+		"Create notification is forbidden for role admin": {
 			role:       iam.Admin,
 			wantStatus: http.StatusForbidden,
 		},
@@ -215,7 +206,7 @@ func TestListNotifications_Role(t *testing.T) {
 			router, mockNotificationService := setup(t)
 
 			if tt.wantStatus == http.StatusOK {
-				mockNotificationService.EXPECT().ListNotifications(mock.Anything, resultSelector).
+				mockNotificationService.EXPECT().ListNotifications(mock.Anything, mock.Anything).
 					Return([]models.Notification{}, uint64(0), nil).
 					Once()
 			}
@@ -223,7 +214,7 @@ func TestListNotifications_Role(t *testing.T) {
 			httpassert.New(t, router).
 				Put("/notifications").
 				AuthJwt(integrationTests.CreateJwtTokenWithRole(tt.role)).
-				JsonContentObject(resultSelector).
+				JsonContentObject(query.ResultSelector{}).
 				Expect().
 				StatusCode(tt.wantStatus)
 		})


### PR DESCRIPTION
## What
Add osi.user role to notification service

## Why
Renaming of the user, but staying backwards compatible.

## References
https://jira.greenbone.net/browse/ARTOSI-321

## Checklist
- [ ] Tests