### PR TITLE
Change: Allow all new roles to endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+# Install via pipx `sudo apt install pipx && pipx ensurepath && pipx install pre-commit`
+# reload your shell `source ~/.bashrc` and then install via `pre-commit install --hook-type pre-push`.
+# This runs basic linting and tests to prevent a failing pipeline
+repos:
+  - repo: local
+    hooks:
+      - id: lint-backend
+        name: Backend Linting
+        entry: make lint
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      - id: test-backend
+        name: Backend Tests
+        entry: make test
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      - id: govulncheck
+        name: Check for Vulnerabilities
+        entry: make govulncheck
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      - id: generate-mocks
+        name: Generate Mocks
+        entry: bash -c "make generate-code && git diff --exit-code"
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      - id: generate-api-docs
+        name: Generate API docs
+        entry: bash -c "make api-docs && git diff --exit-code"
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ all: generate-code api-docs lint build test
 SWAG = github.com/swaggo/swag/cmd/swag@v1.16.4
 MOCKERY = github.com/vektra/mockery/v3@v3.5.1
 GOLANGCI-LINT = github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+GOVULNCHECK = golang.org/x/vuln/cmd/govulncheck@latest
+
+.PHONY: govulncheck
+govulncheck:
+	go run $(GOVULNCHECK) ./...
 
 .PHONY: help
 help: ## show this help.

--- a/pkg/web/iam/roles.go
+++ b/pkg/web/iam/roles.go
@@ -5,8 +5,11 @@
 package iam
 
 const (
-	User         = "user"
-	OsiUser      = "osi.user"
-	Admin        = "admin"
-	Notification = "opensight_notification_role"
+	OsiViewer         = "osi.viewer"
+	User              = "user" // Stays to ensure backwards compatibility
+	OsiUser           = "osi.user"
+	Admin             = "admin" // Stays to ensure backwards compatibility
+	OsiAdmin          = "osi.admin"
+	Notification      = "opensight_notification_role" // Only a service user
+	NotificationAdmin = "notification.admin"          // Same as Admin
 )

--- a/pkg/web/mailcontroller/checkMailServer.go
+++ b/pkg/web/mailcontroller/checkMailServer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
 	"github.com/greenbone/opensight-notification-service/pkg/web/ginEx"
+	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
 	"github.com/greenbone/opensight-notification-service/pkg/web/mailcontroller/maildto"
 	"github.com/greenbone/opensight-notification-service/pkg/web/middleware"
 )
@@ -28,7 +29,7 @@ func AddCheckMailServerController(
 	}
 
 	group := router.Group("/notification-channel/mail").
-		Use(middleware.AuthorizeRoles(auth, "admin")...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
 
 	group.POST("/check", ctrl.CheckMailServer)
 

--- a/pkg/web/mailcontroller/checkMailServer_test.go
+++ b/pkg/web/mailcontroller/checkMailServer_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/greenbone/keycloak-client-golang/auth"
 	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice"
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice/mocks"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
+	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
+	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func setup(t *testing.T) (*gin.Engine, *mocks.MailChannelService) {
@@ -21,6 +25,20 @@ func setup(t *testing.T) (*gin.Engine, *mocks.MailChannelService) {
 
 	AddCheckMailServerController(engine, notificationChannelServicer, testhelper.MockAuthMiddlewareWithAdmin, registry)
 	return engine, notificationChannelServicer
+}
+
+func setupCheckMailServerWithAuth(t *testing.T) *gin.Engine {
+	registry := errmap.NewRegistry()
+	engine := testhelper.NewTestWebEngine(registry)
+	mailChannelService := mocks.NewMailChannelService(t)
+
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	require.NoError(t, err)
+
+	mailChannelService.On("CheckNotificationChannelConnectivity", mock.Anything, mock.Anything).Maybe().Return(nil)
+
+	AddCheckMailServerController(engine, mailChannelService, authMiddleware, registry)
+	return engine
 }
 
 func TestCheckMailServer(t *testing.T) {
@@ -124,4 +142,46 @@ func TestCheckMailServer(t *testing.T) {
 				"title": "Server is unreachable"
 			}`)
 	})
+}
+
+func TestCheckMailServer_ForbiddenRoles(t *testing.T) {
+	t.Parallel()
+
+	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
+
+	for _, role := range forbiddenRoles {
+		t.Run("Check mail server is forbidden for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router := setupCheckMailServerWithAuth(t)
+
+			httpassert.New(t, router).
+				Post("/notification-channel/mail/check").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				Content(`{"domain":"example.com","port":123}`).
+				Expect().
+				StatusCode(http.StatusForbidden)
+		})
+	}
+}
+
+func TestCheckMailServer_AllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
+
+	for _, role := range allowedRoles {
+		t.Run("Check mail server is allowed for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router := setupCheckMailServerWithAuth(t)
+
+			httpassert.New(t, router).
+				Post("/notification-channel/mail/check").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				Content(`{"domain":"example.com","port":123}`).
+				Expect().
+				StatusCode(http.StatusNoContent)
+		})
+	}
 }

--- a/pkg/web/mailcontroller/checkMailServer_test.go
+++ b/pkg/web/mailcontroller/checkMailServer_test.go
@@ -1,7 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG <https://greenbone.net>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package mailcontroller
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -23,22 +29,11 @@ func setup(t *testing.T) (*gin.Engine, *mocks.MailChannelService) {
 
 	notificationChannelServicer := mocks.NewMailChannelService(t)
 
-	AddCheckMailServerController(engine, notificationChannelServicer, testhelper.MockAuthMiddlewareWithAdmin, registry)
-	return engine, notificationChannelServicer
-}
-
-func setupCheckMailServerWithAuth(t *testing.T) *gin.Engine {
-	registry := errmap.NewRegistry()
-	engine := testhelper.NewTestWebEngine(registry)
-	mailChannelService := mocks.NewMailChannelService(t)
-
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
-	mailChannelService.On("CheckNotificationChannelConnectivity", mock.Anything, mock.Anything).Maybe().Return(nil)
-
-	AddCheckMailServerController(engine, mailChannelService, authMiddleware, registry)
-	return engine
+	AddCheckMailServerController(engine, notificationChannelServicer, authMiddleware, registry)
+	return engine, notificationChannelServicer
 }
 
 func TestCheckMailServer(t *testing.T) {
@@ -58,6 +53,7 @@ func TestCheckMailServer(t *testing.T) {
 				"username": "testUser",
 				"password": "123"
 			}`).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusNoContent).
 			NoContent()
@@ -69,6 +65,7 @@ func TestCheckMailServer(t *testing.T) {
 		httpassert.New(t, engine).
 			Post("/notification-channel/mail/check").
 			Content(`-`).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusBadRequest).
 			Json(`{
@@ -84,6 +81,7 @@ func TestCheckMailServer(t *testing.T) {
 		httpassert.New(t, engine).
 			Post("/notification-channel/mail/check").
 			Content(`{}`).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusBadRequest).
 			Json(`{
@@ -109,6 +107,7 @@ func TestCheckMailServer(t *testing.T) {
 				"username": "",
 				"password": ""
 			}`).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusBadRequest).
 			Json(`{
@@ -135,6 +134,7 @@ func TestCheckMailServer(t *testing.T) {
 				"isAuthenticationRequired": false,
 				"isTlsEnforced": false
 			}`).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusUnprocessableEntity).
 			Json(`{
@@ -144,44 +144,52 @@ func TestCheckMailServer(t *testing.T) {
 	})
 }
 
-func TestCheckMailServer_ForbiddenRoles(t *testing.T) {
+func TestCheckMailServer_Permissions(t *testing.T) {
 	t.Parallel()
 
-	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
-
-	for _, role := range forbiddenRoles {
-		t.Run("Check mail server is forbidden for role "+role, func(t *testing.T) {
-			t.Parallel()
-
-			router := setupCheckMailServerWithAuth(t)
-
-			httpassert.New(t, router).
-				Post("/notification-channel/mail/check").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Content(`{"domain":"example.com","port":123}`).
-				Expect().
-				StatusCode(http.StatusForbidden)
-		})
+	var endpoints = []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"Create mail channel", http.MethodPost, "/notification-channel/mail/check"},
 	}
-}
 
-func TestCheckMailServer_AllowedRoles(t *testing.T) {
-	t.Parallel()
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		// ensure this is the same as in iam/roles.go
+		{iam.OsiViewer, false},
+		{iam.User, false},
+		{iam.OsiUser, false},
+		{iam.OsiAdmin, false},
+		{iam.Admin, true},
+		{iam.NotificationAdmin, true},
+		{iam.Notification, false},
+	}
 
-	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
+	for _, tt := range tests {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
+				t.Parallel()
 
-	for _, role := range allowedRoles {
-		t.Run("Check mail server is allowed for role "+role, func(t *testing.T) {
-			t.Parallel()
+				router, notificationChannelServicer := setup(t)
+				notificationChannelServicer.EXPECT().CheckNotificationChannelConnectivity(mock.Anything, mock.Anything).Maybe().Return(nil)
 
-			router := setupCheckMailServerWithAuth(t)
+				req, _ := http.NewRequest(ep.method, ep.path, strings.NewReader(`{"domain":"example.com","port":123}`))
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
 
-			httpassert.New(t, router).
-				Post("/notification-channel/mail/check").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Content(`{"domain":"example.com","port":123}`).
-				Expect().
-				StatusCode(http.StatusNoContent)
-		})
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
+			})
+		}
 	}
 }

--- a/pkg/web/mailcontroller/mailController.go
+++ b/pkg/web/mailcontroller/mailController.go
@@ -10,6 +10,7 @@ import (
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
 	"github.com/greenbone/opensight-notification-service/pkg/web/ginEx"
+	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
 	"github.com/greenbone/opensight-notification-service/pkg/web/mailcontroller/maildto"
 	"github.com/greenbone/opensight-notification-service/pkg/web/middleware"
 )
@@ -55,7 +56,7 @@ func (mc *MailController) configureMappings(r errmap.ErrorRegistry) {
 
 func (mc *MailController) registerRoutes(router gin.IRouter, auth gin.HandlerFunc) {
 	group := router.Group("/notification-channel/mail").
-		Use(middleware.AuthorizeRoles(auth, "admin")...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
 	group.POST("", mc.CreateMailChannel)
 	group.GET("", mc.ListMailChannelsByType)
 	group.PUT("/:id", mc.UpdateMailChannel)

--- a/pkg/web/mailcontroller/mailController_test.go
+++ b/pkg/web/mailcontroller/mailController_test.go
@@ -6,39 +6,33 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/greenbone/keycloak-client-golang/auth"
 	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
 	"github.com/greenbone/opensight-notification-service/pkg/models"
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice/mocks"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
+	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
+	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/mailcontroller/maildto"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func getValidNotificationChannel() models.NotificationChannel {
-	id := "mail-id-1"
-	name := "mail1"
-	domain := "example.com"
-	port := 25
-	auth := true
-	tls := true
-	username := "user"
-	password := "pass"
-	maxAttach := 10
-	maxInclude := 5
-	sender := "sender@example.com"
 	return models.NotificationChannel{
-		Id:                       id,
-		ChannelName:              name,
-		Domain:                   &domain,
-		Port:                     &port,
-		IsAuthenticationRequired: &auth,
-		IsTlsEnforced:            &tls,
-		Username:                 &username,
-		Password:                 &password,
-		MaxEmailAttachmentSizeMb: &maxAttach,
-		MaxEmailIncludeSizeMb:    &maxInclude,
-		SenderEmailAddress:       &sender,
+		Id:                       "mail-id-1",
+		ChannelName:              "mail1",
+		Domain:                   new("example.com"),
+		Port:                     new(25),
+		IsAuthenticationRequired: new(true),
+		IsTlsEnforced:            new(true),
+		Username:                 new("user"),
+		Password:                 new("pass"),
+		MaxEmailAttachmentSizeMb: new(10),
+		MaxEmailIncludeSizeMb:    new(5),
+		SenderEmailAddress:       new("sender@example.com"),
 	}
 }
 
@@ -332,6 +326,75 @@ func TestMailController_DeleteMailChannel(t *testing.T) {
 				resp.JsonPath("$", httpassert.HasSize(2))
 			}
 			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func setupWithAuth(t *testing.T) *gin.Engine {
+	registry := errmap.NewRegistry()
+	router := testhelper.NewTestWebEngine(registry)
+	notificationChannelService := mocks.NewNotificationChannelService(t)
+	mailChannelService := mocks.NewMailChannelService(t)
+
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	require.NoError(t, err)
+
+	notificationChannelService.On("ListNotificationChannelsByType", mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+
+	NewMailController(router, notificationChannelService, mailChannelService, authMiddleware, registry)
+	return router
+}
+
+func TestMailController_ForbiddenRoles(t *testing.T) {
+	t.Parallel()
+
+	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
+
+	endpoints := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"Create mail channel", http.MethodPost, "/notification-channel/mail"},
+		{"List mail channels", http.MethodGet, "/notification-channel/mail"},
+		{"Update mail channel", http.MethodPut, "/notification-channel/mail/" + uuid.NewString()},
+		{"Delete mail channel", http.MethodDelete, "/notification-channel/mail/" + uuid.NewString()},
+		{"Check mail server", http.MethodPost, "/notification-channel/mail/" + uuid.NewString() + "/check"},
+	}
+
+	for _, role := range forbiddenRoles {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
+				t.Parallel()
+
+				router := setupWithAuth(t)
+
+				httpassert.New(t, router).
+					Perform(ep.method, ep.path).
+					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+					Expect().
+					StatusCode(http.StatusForbidden)
+			})
+		}
+	}
+}
+
+func TestMailController_AllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
+
+	for _, role := range allowedRoles {
+		t.Run("List mail channels is allowed for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router := setupWithAuth(t)
+
+			httpassert.New(t, router).
+				Get("/notification-channel/mail").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				Expect().
+				StatusCode(http.StatusOK)
 		})
 	}
 }

--- a/pkg/web/mailcontroller/mailController_test.go
+++ b/pkg/web/mailcontroller/mailController_test.go
@@ -1,8 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG <https://greenbone.net>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package mailcontroller
 
 import (
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -339,18 +344,17 @@ func setupWithAuth(t *testing.T) *gin.Engine {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
-	notificationChannelService.On("ListNotificationChannelsByType", mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	notificationChannelService.EXPECT().ListNotificationChannelsByType(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	notificationChannelService.EXPECT().DeleteNotificationChannel(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
 
 	NewMailController(router, notificationChannelService, mailChannelService, authMiddleware, registry)
 	return router
 }
 
-func TestMailController_ForbiddenRoles(t *testing.T) {
+func TestMailController_Permissions(t *testing.T) {
 	t.Parallel()
 
-	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
-
-	endpoints := []struct {
+	var endpoints = []struct {
 		name   string
 		method string
 		path   string
@@ -362,39 +366,39 @@ func TestMailController_ForbiddenRoles(t *testing.T) {
 		{"Check mail server", http.MethodPost, "/notification-channel/mail/" + uuid.NewString() + "/check"},
 	}
 
-	for _, role := range forbiddenRoles {
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		// ensure this is the same as in iam/roles.go
+		{iam.OsiViewer, false},
+		{iam.User, false},
+		{iam.OsiUser, false},
+		{iam.OsiAdmin, false},
+		{iam.Admin, true},
+		{iam.NotificationAdmin, true},
+		{iam.Notification, false},
+	}
+
+	for _, tt := range tests {
 		for _, ep := range endpoints {
-			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
 				t.Parallel()
 
 				router := setupWithAuth(t)
 
-				httpassert.New(t, router).
-					Perform(ep.method, ep.path).
-					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-					Expect().
-					StatusCode(http.StatusForbidden)
+				req, _ := http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
 			})
 		}
-	}
-}
-
-func TestMailController_AllowedRoles(t *testing.T) {
-	t.Parallel()
-
-	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
-
-	for _, role := range allowedRoles {
-		t.Run("List mail channels is allowed for role "+role, func(t *testing.T) {
-			t.Parallel()
-
-			router := setupWithAuth(t)
-
-			httpassert.New(t, router).
-				Get("/notification-channel/mail").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Expect().
-				StatusCode(http.StatusOK)
-		})
 	}
 }

--- a/pkg/web/mattermostcontroller/mattermostController.go
+++ b/pkg/web/mattermostcontroller/mattermostController.go
@@ -34,7 +34,7 @@ func NewMattermostController(
 	}
 
 	group := router.Group("/notification-channel/mattermost").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
 	group.Use(errorHandler(gin.ErrorTypePrivate))
 
 	group.POST("", ctrl.createMattermostChannel)

--- a/pkg/web/mattermostcontroller/mattermostController_test.go
+++ b/pkg/web/mattermostcontroller/mattermostController_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
 	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,50 +26,60 @@ func setup(t *testing.T) *gin.Engine {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
+	// We only test permissions, the method ifself is not part of these tests.
+	notificationChannelService.
+		On("ListNotificationChannelsByType", mock.Anything, mock.Anything).
+		Maybe().
+		Return(nil, nil)
+
 	NewMattermostController(router, notificationChannelService, mattermostChannelService, authMiddleware, registry)
 	return router
 }
 
-func TestMattermostController(t *testing.T) {
+func TestMattermostController_ForbiddenRoles(t *testing.T) {
 	router := setup(t)
 
-	t.Run("Create mattermost channel is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Post(`/notification-channel/mattermost`).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
 
-	t.Run("Get mattermost channels is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Get(`/notification-channel/mattermost`).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	type endpoint struct {
+		name   string
+		method string
+		path   string
+	}
 
-	t.Run("Update mattermost channel is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Putf(`/notification-channel/mattermost/%s`, uuid.New()).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	endpoints := []endpoint{
+		{"Create mattermost channel", http.MethodPost, "/notification-channel/mattermost"},
+		{"List mattermost channels", http.MethodGet, "/notification-channel/mattermost"},
+		{"Update mattermost channel", http.MethodPut, "/notification-channel/mattermost/" + uuid.NewString()},
+		{"Delete mattermost channel", http.MethodDelete, "/notification-channel/mattermost/" + uuid.NewString()},
+		{"Check mattermost channel", http.MethodPost, "/notification-channel/mattermost/check"},
+	}
 
-	t.Run("Delete mattermost channel is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Deletef(`/notification-channel/mattermost/%s`, uuid.New()).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	for _, role := range forbiddenRoles {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
+				httpassert.New(t, router).
+					Perform(ep.method, ep.path).
+					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+					Expect().
+					StatusCode(http.StatusForbidden)
+			})
+		}
+	}
+}
 
-	t.Run("Check mattermost channels is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Post(`/notification-channel/mattermost/check`).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+func TestMattermostController_AllowedRoles(t *testing.T) {
+	router := setup(t)
+
+	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
+
+	for _, role := range allowedRoles {
+		t.Run("Access is granted for role "+role, func(t *testing.T) {
+			httpassert.New(t, router).
+				Get(`/notification-channel/mattermost`).
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				Expect().
+				StatusCode(http.StatusOK)
+		})
+	}
 }

--- a/pkg/web/mattermostcontroller/mattermostController_test.go
+++ b/pkg/web/mattermostcontroller/mattermostController_test.go
@@ -26,7 +26,7 @@ func setup(t *testing.T) *gin.Engine {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
-	// We only test permissions, the method ifself is not part of these tests.
+	// We only test permissions, the method itself is not part of these tests.
 	notificationChannelService.
 		On("ListNotificationChannelsByType", mock.Anything, mock.Anything).
 		Maybe().

--- a/pkg/web/mattermostcontroller/mattermostController_test.go
+++ b/pkg/web/mattermostcontroller/mattermostController_test.go
@@ -1,13 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG <https://greenbone.net>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package mattermostcontroller
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/greenbone/keycloak-client-golang/auth"
-	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice/mocks"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
 	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
@@ -17,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setup(t *testing.T) *gin.Engine {
+func setupWithAuth(t *testing.T) *gin.Engine {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 	notificationChannelService := mocks.NewNotificationChannelService(t)
@@ -26,28 +30,21 @@ func setup(t *testing.T) *gin.Engine {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
-	// We only test permissions, the method itself is not part of these tests.
-	notificationChannelService.
-		On("ListNotificationChannelsByType", mock.Anything, mock.Anything).
-		Maybe().
-		Return(nil, nil)
+	notificationChannelService.EXPECT().ListNotificationChannelsByType(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	notificationChannelService.EXPECT().DeleteNotificationChannel(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
 
 	NewMattermostController(router, notificationChannelService, mattermostChannelService, authMiddleware, registry)
 	return router
 }
 
-func TestMattermostController_ForbiddenRoles(t *testing.T) {
-	router := setup(t)
+func TestMattermostController_Permissions(t *testing.T) {
+	t.Parallel()
 
-	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
-
-	type endpoint struct {
+	var endpoints = []struct {
 		name   string
 		method string
 		path   string
-	}
-
-	endpoints := []endpoint{
+	}{
 		{"Create mattermost channel", http.MethodPost, "/notification-channel/mattermost"},
 		{"List mattermost channels", http.MethodGet, "/notification-channel/mattermost"},
 		{"Update mattermost channel", http.MethodPut, "/notification-channel/mattermost/" + uuid.NewString()},
@@ -55,31 +52,39 @@ func TestMattermostController_ForbiddenRoles(t *testing.T) {
 		{"Check mattermost channel", http.MethodPost, "/notification-channel/mattermost/check"},
 	}
 
-	for _, role := range forbiddenRoles {
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		// ensure this is the same as in iam/roles.go
+		{iam.OsiViewer, false},
+		{iam.User, false},
+		{iam.OsiUser, false},
+		{iam.OsiAdmin, false},
+		{iam.Admin, true},
+		{iam.NotificationAdmin, true},
+		{iam.Notification, false},
+	}
+
+	for _, tt := range tests {
 		for _, ep := range endpoints {
-			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
-				httpassert.New(t, router).
-					Perform(ep.method, ep.path).
-					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-					Expect().
-					StatusCode(http.StatusForbidden)
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
+				t.Parallel()
+
+				router := setupWithAuth(t)
+
+				req, _ := http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
 			})
 		}
-	}
-}
-
-func TestMattermostController_AllowedRoles(t *testing.T) {
-	router := setup(t)
-
-	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
-
-	for _, role := range allowedRoles {
-		t.Run("Access is granted for role "+role, func(t *testing.T) {
-			httpassert.New(t, router).
-				Get(`/notification-channel/mattermost`).
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Expect().
-				StatusCode(http.StatusOK)
-		})
 	}
 }

--- a/pkg/web/notificationcontroller/notificationController.go
+++ b/pkg/web/notificationcontroller/notificationController.go
@@ -35,7 +35,7 @@ func AddNotificationController(
 
 	groupPath := "/notifications"
 
-	router.Group(groupPath).Use(middleware.AuthorizeRoles(auth, iam.User, iam.OsiUser)...).
+	router.Group(groupPath).Use(middleware.AuthorizeRoles(auth, iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin)...).
 		PUT("", ctrl.ListNotifications).
 		GET("/options", ctrl.GetOptions)
 	// only to be used by other backend services

--- a/pkg/web/notificationcontroller/notificationController_test.go
+++ b/pkg/web/notificationcontroller/notificationController_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/greenbone/opensight-golang-libraries/pkg/query"
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/filter"
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/paging"
-	"github.com/greenbone/opensight-notification-service/pkg/helper"
 	"github.com/greenbone/opensight-notification-service/pkg/models"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
 	"github.com/stretchr/testify/mock"
@@ -54,36 +53,47 @@ func setup(t *testing.T) (*gin.Engine, *mocks.NotificationService) {
 	return router, mockNotificationService
 }
 
-func TestRuleController_Role(t *testing.T) {
+func TestCreateNotification_ForbiddenRoles(t *testing.T) {
 	t.Parallel()
 
-	wantStatus := http.StatusForbidden
+	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Admin, iam.NotificationAdmin}
 
-	tests := map[string]struct {
-		role string
-	}{
-		"Create notification is forbidden for role user": {
-			role: iam.User,
-		},
-		"Create notification is forbidden for role osi.user": {
-			role: iam.OsiUser,
-		},
-		"Create notification is forbidden for role admin": {
-			role: iam.Admin,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, role := range forbiddenRoles {
+		t.Run("Create notification is forbidden for role "+role, func(t *testing.T) {
 			t.Parallel()
 
 			router, _ := setup(t)
 
 			httpassert.New(t, router).
 				Post("/notifications").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(tt.role)).
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
 				Expect().
-				StatusCode(wantStatus)
+				StatusCode(http.StatusForbidden)
+		})
+	}
+}
+
+func TestCreateNotification_AllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	allowedRoles := []string{iam.Notification}
+
+	for _, role := range allowedRoles {
+		t.Run("Create notification is allowed for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router, mockNotificationService := setup(t)
+
+			mockNotificationService.EXPECT().CreateNotification(mock.Anything, mock.Anything).
+				Maybe().
+				Return(models.Notification{}, nil)
+
+			httpassert.New(t, router).
+				Post("/notifications").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				JsonContentObject(getNotification()).
+				Expect().
+				StatusCode(http.StatusCreated)
 		})
 	}
 }
@@ -178,45 +188,48 @@ func TestListNotifications(t *testing.T) {
 	}
 }
 
-func TestListNotifications_Role(t *testing.T) {
+func TestListNotifications_ForbiddenRoles(t *testing.T) {
 	t.Parallel()
 
-	tests := map[string]struct {
-		role       string
-		wantStatus int
-	}{
-		"List notification is allowed for role user": {
-			role:       iam.User,
-			wantStatus: http.StatusOK,
-		},
-		"List notification is allowed for role osi.user": {
-			role:       iam.OsiUser,
-			wantStatus: http.StatusOK,
-		},
-		"List notification is forbidden for role admin": {
-			role:       iam.Admin,
-			wantStatus: http.StatusForbidden,
-		},
-	}
+	forbiddenRoles := []string{iam.Admin, iam.NotificationAdmin}
 
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, role := range forbiddenRoles {
+		t.Run("List notifications is forbidden for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router, _ := setup(t)
+
+			httpassert.New(t, router).
+				Put("/notifications").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				Content("{}").
+				Expect().
+				StatusCode(http.StatusForbidden)
+		})
+	}
+}
+
+func TestListNotifications_AllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	allowedRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin}
+
+	for _, role := range allowedRoles {
+		t.Run("List notifications is allowed for role "+role, func(t *testing.T) {
 			t.Parallel()
 
 			router, mockNotificationService := setup(t)
 
-			if tt.wantStatus == http.StatusOK {
-				mockNotificationService.EXPECT().ListNotifications(mock.Anything, mock.Anything).
-					Return([]models.Notification{}, uint64(0), nil).
-					Once()
-			}
+			mockNotificationService.EXPECT().ListNotifications(mock.Anything, mock.Anything).
+				Return([]models.Notification{}, uint64(0), nil).
+				Once()
 
 			httpassert.New(t, router).
 				Put("/notifications").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(tt.role)).
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
 				Content("{}").
 				Expect().
-				StatusCode(tt.wantStatus)
+				StatusCode(http.StatusOK)
 		})
 	}
 }
@@ -249,7 +262,7 @@ func TestCreateNotification(t *testing.T) {
 			notificationToCreate: someNotification,
 			mockServiceReturn:    mockServiceReturn{item: wantNotification},
 			want: want{
-				notificationServiceArg: helper.ToPtr(someNotification),
+				notificationServiceArg: new(someNotification),
 				responseCode:           http.StatusCreated,
 				responseParsed:         query.ResponseWithMetadata[models.Notification]{Data: wantNotification},
 			},
@@ -259,7 +272,7 @@ func TestCreateNotification(t *testing.T) {
 			notificationToCreate: someNotification,
 			mockServiceReturn:    mockServiceReturn{item: models.Notification{}, err: errors.New("some internal error")},
 			want: want{
-				notificationServiceArg: helper.ToPtr(someNotification),
+				notificationServiceArg: new(someNotification),
 				responseCode:           http.StatusInternalServerError,
 			},
 		},

--- a/pkg/web/notificationcontroller/notificationController_test.go
+++ b/pkg/web/notificationcontroller/notificationController_test.go
@@ -7,6 +7,7 @@ package notificationcontroller
 import (
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -53,48 +54,50 @@ func setup(t *testing.T) (*gin.Engine, *mocks.NotificationService) {
 	return router, mockNotificationService
 }
 
-func TestCreateNotification_ForbiddenRoles(t *testing.T) {
+func TestCreateNotification_Permissions(t *testing.T) {
 	t.Parallel()
 
-	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Admin, iam.NotificationAdmin}
-
-	for _, role := range forbiddenRoles {
-		t.Run("Create notification is forbidden for role "+role, func(t *testing.T) {
-			t.Parallel()
-
-			router, _ := setup(t)
-
-			httpassert.New(t, router).
-				Post("/notifications").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Expect().
-				StatusCode(http.StatusForbidden)
-		})
+	var endpoints = []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"Create notification channel", http.MethodPost, "/notifications"},
 	}
-}
 
-func TestCreateNotification_AllowedRoles(t *testing.T) {
-	t.Parallel()
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		{iam.OsiViewer, false},
+		{iam.User, false},
+		{iam.OsiUser, false},
+		{iam.OsiAdmin, false},
+		{iam.Admin, false},
+		{iam.NotificationAdmin, false},
+		{iam.Notification, true},
+	}
 
-	allowedRoles := []string{iam.Notification}
+	for _, tt := range tests {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
+				t.Parallel()
 
-	for _, role := range allowedRoles {
-		t.Run("Create notification is allowed for role "+role, func(t *testing.T) {
-			t.Parallel()
+				router, _ := setup(t)
 
-			router, mockNotificationService := setup(t)
+				req, _ := http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
 
-			mockNotificationService.EXPECT().CreateNotification(mock.Anything, mock.Anything).
-				Maybe().
-				Return(models.Notification{}, nil)
-
-			httpassert.New(t, router).
-				Post("/notifications").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				JsonContentObject(getNotification()).
-				Expect().
-				StatusCode(http.StatusCreated)
-		})
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
+			})
+		}
 	}
 }
 
@@ -188,49 +191,52 @@ func TestListNotifications(t *testing.T) {
 	}
 }
 
-func TestListNotifications_ForbiddenRoles(t *testing.T) {
+func TestListNotifications_Permissions(t *testing.T) {
 	t.Parallel()
 
-	forbiddenRoles := []string{iam.Admin, iam.NotificationAdmin}
-
-	for _, role := range forbiddenRoles {
-		t.Run("List notifications is forbidden for role "+role, func(t *testing.T) {
-			t.Parallel()
-
-			router, _ := setup(t)
-
-			httpassert.New(t, router).
-				Put("/notifications").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Content("{}").
-				Expect().
-				StatusCode(http.StatusForbidden)
-		})
+	var endpoints = []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"List notifications channels", http.MethodPut, "/notifications"},
+		{"Get options", http.MethodGet, "/notifications/options"},
 	}
-}
 
-func TestListNotifications_AllowedRoles(t *testing.T) {
-	t.Parallel()
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		// ensure this is the same as in iam/roles.go
+		{iam.OsiViewer, true},
+		{iam.User, true},
+		{iam.OsiUser, true},
+		{iam.OsiAdmin, true},
+		{iam.Admin, false},
+		{iam.NotificationAdmin, false},
+		{iam.Notification, false},
+	}
 
-	allowedRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin}
+	for _, tt := range tests {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
+				t.Parallel()
 
-	for _, role := range allowedRoles {
-		t.Run("List notifications is allowed for role "+role, func(t *testing.T) {
-			t.Parallel()
+				router, _ := setup(t)
 
-			router, mockNotificationService := setup(t)
+				req, _ := http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
 
-			mockNotificationService.EXPECT().ListNotifications(mock.Anything, mock.Anything).
-				Return([]models.Notification{}, uint64(0), nil).
-				Once()
-
-			httpassert.New(t, router).
-				Put("/notifications").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Content("{}").
-				Expect().
-				StatusCode(http.StatusOK)
-		})
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/web/origincontroller/originController_test.go
+++ b/pkg/web/origincontroller/originController_test.go
@@ -10,14 +10,18 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/greenbone/keycloak-client-golang/auth"
 	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
 	"github.com/greenbone/opensight-notification-service/pkg/entities"
 	"github.com/greenbone/opensight-notification-service/pkg/models"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
+	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
+	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/origincontroller/mocks"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRegisterOrigins(t *testing.T) {
@@ -127,43 +131,57 @@ func TestRegisterOrigins(t *testing.T) {
 	}
 }
 
-func TestRegisterOrigins_Auth(t *testing.T) {
-	tests := map[string]struct {
-		authMiddleware   gin.HandlerFunc
-		wantResponseCode int
-	}{
-		"notification user is allowed to register origins": {
-			authMiddleware:   testhelper.MockAuthMiddlewareWithNotificationUser,
-			wantResponseCode: http.StatusNoContent,
-		},
-		"normal users are not allowed to register origins": {
-			authMiddleware:   testhelper.MockAuthMiddleware,
-			wantResponseCode: http.StatusForbidden,
-		},
-		"admins are not allowed to register origins": {
-			authMiddleware:   testhelper.MockAuthMiddlewareWithAdmin,
-			wantResponseCode: http.StatusForbidden,
-		},
-	}
+func setupWithAuth(t *testing.T) (*gin.Engine, *mocks.OriginService) {
+	mockService := mocks.NewOriginService(t)
+	registry := errmap.NewRegistry()
+	router := testhelper.NewTestWebEngine(registry)
 
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			mockService := mocks.NewOriginService(t)
-			if tt.wantResponseCode == http.StatusNoContent {
-				mockService.EXPECT().UpsertOrigins(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-			}
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	require.NoError(t, err)
 
-			registry := errmap.NewRegistry()
-			router := testhelper.NewTestWebEngine(registry)
+	_ = NewOriginController(router, mockService, authMiddleware)
+	return router, mockService
+}
 
-			_ = NewOriginController(router, mockService, tt.authMiddleware)
+func TestRegisterOrigins_ForbiddenRoles(t *testing.T) {
+	t.Parallel()
 
-			request := httpassert.New(t, router)
+	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin}
 
-			request.Put("/origins/serviceX").
+	for _, role := range forbiddenRoles {
+		t.Run("Register origins is forbidden for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router, _ := setupWithAuth(t)
+
+			httpassert.New(t, router).
+				Put("/origins/serviceX").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
 				JsonContentObject([]models.Origin{{Name: "Origin", Class: "origin/class"}}).
 				Expect().
-				StatusCode(tt.wantResponseCode)
+				StatusCode(http.StatusForbidden)
+		})
+	}
+}
+
+func TestRegisterOrigins_AllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	allowedRoles := []string{iam.Notification}
+
+	for _, role := range allowedRoles {
+		t.Run("Register origins is allowed for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router, mockService := setupWithAuth(t)
+			mockService.EXPECT().UpsertOrigins(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+			httpassert.New(t, router).
+				Put("/origins/serviceX").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				JsonContentObject([]models.Origin{{Name: "Origin", Class: "origin/class"}}).
+				Expect().
+				StatusCode(http.StatusNoContent)
 		})
 	}
 }

--- a/pkg/web/origincontroller/originController_test.go
+++ b/pkg/web/origincontroller/originController_test.go
@@ -7,6 +7,7 @@ package origincontroller
 import (
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -131,7 +132,7 @@ func TestRegisterOrigins(t *testing.T) {
 	}
 }
 
-func setupWithAuth(t *testing.T) (*gin.Engine, *mocks.OriginService) {
+func setupWithAuth(t *testing.T) *gin.Engine {
 	mockService := mocks.NewOriginService(t)
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
@@ -139,49 +140,54 @@ func setupWithAuth(t *testing.T) (*gin.Engine, *mocks.OriginService) {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
-	_ = NewOriginController(router, mockService, authMiddleware)
-	return router, mockService
+	NewOriginController(router, mockService, authMiddleware)
+	return router
 }
 
-func TestRegisterOrigins_ForbiddenRoles(t *testing.T) {
+func TestRegisterOrigins_Permissions(t *testing.T) {
 	t.Parallel()
 
-	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin}
-
-	for _, role := range forbiddenRoles {
-		t.Run("Register origins is forbidden for role "+role, func(t *testing.T) {
-			t.Parallel()
-
-			router, _ := setupWithAuth(t)
-
-			httpassert.New(t, router).
-				Put("/origins/serviceX").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				JsonContentObject([]models.Origin{{Name: "Origin", Class: "origin/class"}}).
-				Expect().
-				StatusCode(http.StatusForbidden)
-		})
+	var endpoints = []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"Register origins", http.MethodPut, "/origins/serviceX"},
 	}
-}
 
-func TestRegisterOrigins_AllowedRoles(t *testing.T) {
-	t.Parallel()
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		// ensure this is the same as in iam/roles.go
+		{iam.OsiViewer, false},
+		{iam.User, false},
+		{iam.OsiUser, false},
+		{iam.OsiAdmin, false},
+		{iam.Admin, false},
+		{iam.NotificationAdmin, false},
+		{iam.Notification, true},
+	}
 
-	allowedRoles := []string{iam.Notification}
+	for _, tt := range tests {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
+				t.Parallel()
 
-	for _, role := range allowedRoles {
-		t.Run("Register origins is allowed for role "+role, func(t *testing.T) {
-			t.Parallel()
+				router := setupWithAuth(t)
 
-			router, mockService := setupWithAuth(t)
-			mockService.EXPECT().UpsertOrigins(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+				req, _ := http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
 
-			httpassert.New(t, router).
-				Put("/origins/serviceX").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				JsonContentObject([]models.Origin{{Name: "Origin", Class: "origin/class"}}).
-				Expect().
-				StatusCode(http.StatusNoContent)
-		})
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
+			})
+		}
 	}
 }

--- a/pkg/web/rulecontroller/ruleController.go
+++ b/pkg/web/rulecontroller/ruleController.go
@@ -53,7 +53,7 @@ func NewRuleController(
 
 func (c *RuleController) RegisterRoutes(router gin.IRouter, auth gin.HandlerFunc) {
 	group := router.Group("/rules").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
 	group.GET("/:id", c.GetRule)
 	group.POST("", c.CreateRule)
 	group.PUT("/:id", c.UpdateRule)

--- a/pkg/web/rulecontroller/ruleController_test.go
+++ b/pkg/web/rulecontroller/ruleController_test.go
@@ -11,15 +11,17 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/greenbone/keycloak-client-golang/auth"
 	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
+	"github.com/greenbone/opensight-notification-service/pkg/models"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
 	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
 	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/rulecontroller/mocks"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-func setup(t *testing.T) *gin.Engine {
+func setup(t *testing.T) (*gin.Engine, *mocks.RuleService) {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 	ruleService := mocks.NewRuleService(t)
@@ -27,50 +29,77 @@ func setup(t *testing.T) *gin.Engine {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
+	ruleService.On("List", mock.Anything).Maybe().Return([]models.Rule{}, nil)
+	ruleService.On("GetAllRuleOptions", mock.Anything).Maybe().Return(&models.RuleOptions{}, nil)
+
 	NewRuleController(router, ruleService, authMiddleware, registry)
-	return router
+	return router, ruleService
 }
 
-func TestRuleController(t *testing.T) {
+func TestRuleController_ForbiddenRoles(t *testing.T) {
 	t.Parallel()
-	setup(t)
 
-	wantStatus := http.StatusForbidden
+	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
 
-	tests := map[string]struct {
-		method   string
-		endpoint string
+	endpoints := []struct {
+		name   string
+		method string
+		path   string
 	}{
-		"Create rule is forbidden for role user": {
-			method:   http.MethodPost,
-			endpoint: `/rules`,
-		},
-		"Get rule is forbidden for role user": {
-			method:   http.MethodGet,
-			endpoint: `/rules/123e4567-e89b-12d3-a456-426614174000`,
-		},
-		"List rules is forbidden for role user": {
-			method:   http.MethodGet,
-			endpoint: `/rules`,
-		},
-		"Update rule is forbidden for role user": {
-			method:   http.MethodPut,
-			endpoint: `/rules/123e4567-e89b-12d3-a456-426614174000`,
-		},
-		"Delete rule is forbidden for role user": {
-			method:   http.MethodDelete,
-			endpoint: `/rules/123e4567-e89b-12d3-a456-426614174000`,
-		},
+		{"Create rule", http.MethodPost, "/rules"},
+		{"Get rule", http.MethodGet, "/rules/123e4567-e89b-12d3-a456-426614174000"},
+		{"List rules", http.MethodGet, "/rules"},
+		{"Update rule", http.MethodPut, "/rules/123e4567-e89b-12d3-a456-426614174000"},
+		{"Delete rule", http.MethodDelete, "/rules/123e4567-e89b-12d3-a456-426614174000"},
+		{"Rule options", http.MethodGet, "/rules/ruleoptions"},
 	}
 
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, role := range forbiddenRoles {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
+				t.Parallel()
+
+				router, _ := setup(t)
+
+				httpassert.New(t, router).
+					Perform(ep.method, ep.path).
+					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+					Expect().
+					StatusCode(http.StatusForbidden)
+			})
+		}
+	}
+}
+
+// We use a group for the whole ruleController, testing only the one requiring no request body.
+func TestRuleController_AllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
+
+	for _, role := range allowedRoles {
+		t.Run("List rules is allowed for role "+role, func(t *testing.T) {
 			t.Parallel()
-			httpassert.New(t, setup(t)).
-				Perform(tt.method, tt.endpoint).
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
+
+			router, _ := setup(t)
+
+			httpassert.New(t, router).
+				Get("/rules").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
 				Expect().
-				StatusCode(wantStatus)
+				StatusCode(http.StatusOK)
+		})
+
+		t.Run("Rule options is allowed for role "+role, func(t *testing.T) {
+			t.Parallel()
+
+			router, _ := setup(t)
+
+			httpassert.New(t, router).
+				Get("/rules/ruleoptions").
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				Expect().
+				StatusCode(http.StatusOK)
 		})
 	}
 }

--- a/pkg/web/rulecontroller/ruleController_test.go
+++ b/pkg/web/rulecontroller/ruleController_test.go
@@ -6,11 +6,11 @@ package rulecontroller
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/greenbone/keycloak-client-golang/auth"
-	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
 	"github.com/greenbone/opensight-notification-service/pkg/models"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
 	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setup(t *testing.T) (*gin.Engine, *mocks.RuleService) {
+func setupWithAuth(t *testing.T) *gin.Engine {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 	ruleService := mocks.NewRuleService(t)
@@ -29,19 +29,19 @@ func setup(t *testing.T) (*gin.Engine, *mocks.RuleService) {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
-	ruleService.On("List", mock.Anything).Maybe().Return([]models.Rule{}, nil)
-	ruleService.On("GetAllRuleOptions", mock.Anything).Maybe().Return(&models.RuleOptions{}, nil)
+	ruleService.EXPECT().List(mock.Anything).Maybe().Return([]models.Rule{}, nil)
+	ruleService.EXPECT().GetAllRuleOptions(mock.Anything).Maybe().Return(&models.RuleOptions{}, nil)
+	ruleService.EXPECT().Get(mock.Anything, mock.Anything).Maybe().Return(models.Rule{}, nil)
+	ruleService.EXPECT().Delete(mock.Anything, mock.Anything).Maybe().Return(nil)
 
 	NewRuleController(router, ruleService, authMiddleware, registry)
-	return router, ruleService
+	return router
 }
 
-func TestRuleController_ForbiddenRoles(t *testing.T) {
+func TestRuleController_Permissions(t *testing.T) {
 	t.Parallel()
 
-	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
-
-	endpoints := []struct {
+	var endpoints = []struct {
 		name   string
 		method string
 		path   string
@@ -54,52 +54,39 @@ func TestRuleController_ForbiddenRoles(t *testing.T) {
 		{"Rule options", http.MethodGet, "/rules/ruleoptions"},
 	}
 
-	for _, role := range forbiddenRoles {
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		// ensure this is the same as in iam/roles.go
+		{iam.OsiViewer, false},
+		{iam.User, false},
+		{iam.OsiUser, false},
+		{iam.OsiAdmin, false},
+		{iam.Admin, true},
+		{iam.NotificationAdmin, true},
+		{iam.Notification, false},
+	}
+
+	for _, tt := range tests {
 		for _, ep := range endpoints {
-			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
 				t.Parallel()
 
-				router, _ := setup(t)
+				router := setupWithAuth(t)
 
-				httpassert.New(t, router).
-					Perform(ep.method, ep.path).
-					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-					Expect().
-					StatusCode(http.StatusForbidden)
+				req, _ := http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
 			})
 		}
-	}
-}
-
-// We use a group for the whole ruleController, testing only the one requiring no request body.
-func TestRuleController_AllowedRoles(t *testing.T) {
-	t.Parallel()
-
-	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
-
-	for _, role := range allowedRoles {
-		t.Run("List rules is allowed for role "+role, func(t *testing.T) {
-			t.Parallel()
-
-			router, _ := setup(t)
-
-			httpassert.New(t, router).
-				Get("/rules").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Expect().
-				StatusCode(http.StatusOK)
-		})
-
-		t.Run("Rule options is allowed for role "+role, func(t *testing.T) {
-			t.Parallel()
-
-			router, _ := setup(t)
-
-			httpassert.New(t, router).
-				Get("/rules/ruleoptions").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Expect().
-				StatusCode(http.StatusOK)
-		})
 	}
 }

--- a/pkg/web/teamscontroller/teamsController.go
+++ b/pkg/web/teamscontroller/teamsController.go
@@ -35,7 +35,7 @@ func NewTeamsController(
 	}
 
 	group := router.Group("/notification-channel/teams").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
 	group.Use(errorHandler(gin.ErrorTypePrivate))
 
 	group.POST("", ctrl.CreateTeamsChannel)

--- a/pkg/web/teamscontroller/teamsController_test.go
+++ b/pkg/web/teamscontroller/teamsController_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
 	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,50 +26,57 @@ func setup(t *testing.T) *gin.Engine {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
+	notificationChannelService.
+		On("ListNotificationChannelsByType", mock.Anything, mock.Anything).
+		Maybe().
+		Return(nil, nil)
+
 	NewTeamsController(router, notificationChannelService, teamsChannelService, authMiddleware, registry)
 	return router
 }
 
-func TestTeamsController(t *testing.T) {
+func TestTeamsController_ForbiddenRoles(t *testing.T) {
 	router := setup(t)
 
-	t.Run("Create teams channel is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Post(`/notification-channel/teams`).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
 
-	t.Run("Get teams channels is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Get(`/notification-channel/teams`).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	endpoints := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"Create teams channel", http.MethodPost, "/notification-channel/teams"},
+		{"List teams channels", http.MethodGet, "/notification-channel/teams"},
+		{"Update teams channel", http.MethodPut, "/notification-channel/teams/" + uuid.NewString()},
+		{"Delete teams channel", http.MethodDelete, "/notification-channel/teams/" + uuid.NewString()},
+		{"Check teams channel", http.MethodPost, "/notification-channel/teams/check"},
+	}
 
-	t.Run("Update teams channel is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Putf(`/notification-channel/teams/%s`, uuid.New()).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	for _, role := range forbiddenRoles {
+		for _, ep := range endpoints {
+			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
+				httpassert.New(t, router).
+					Perform(ep.method, ep.path).
+					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+					Expect().
+					StatusCode(http.StatusForbidden)
+			})
+		}
+	}
+}
 
-	t.Run("Delete teams channel is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Deletef(`/notification-channel/teams/%s`, uuid.New()).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+func TestTeamsController_AllowedRoles(t *testing.T) {
+	router := setup(t)
 
-	t.Run("Check teams channels is forbidden for role user", func(t *testing.T) {
-		httpassert.New(t, router).
-			Post(`/notification-channel/teams/check`).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
-			Expect().
-			StatusCode(http.StatusForbidden)
-	})
+	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
+
+	for _, role := range allowedRoles {
+		t.Run("Access is granted for role "+role, func(t *testing.T) {
+			httpassert.New(t, router).
+				Get(`/notification-channel/teams`).
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
+				Expect().
+				StatusCode(http.StatusOK)
+		})
+	}
 }

--- a/pkg/web/teamscontroller/teamsController_test.go
+++ b/pkg/web/teamscontroller/teamsController_test.go
@@ -1,13 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG <https://greenbone.net>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package teamscontroller
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/greenbone/keycloak-client-golang/auth"
-	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice/mocks"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
 	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
@@ -17,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setup(t *testing.T) *gin.Engine {
+func setupWithAuth(t *testing.T) *gin.Engine {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 	notificationChannelService := mocks.NewNotificationChannelService(t)
@@ -26,21 +30,17 @@ func setup(t *testing.T) *gin.Engine {
 	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
 	require.NoError(t, err)
 
-	notificationChannelService.
-		On("ListNotificationChannelsByType", mock.Anything, mock.Anything).
-		Maybe().
-		Return(nil, nil)
+	notificationChannelService.EXPECT().ListNotificationChannelsByType(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
+	notificationChannelService.EXPECT().DeleteNotificationChannel(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
 
 	NewTeamsController(router, notificationChannelService, teamsChannelService, authMiddleware, registry)
 	return router
 }
 
-func TestTeamsController_ForbiddenRoles(t *testing.T) {
-	router := setup(t)
+func TestTeamsController_Permissions(t *testing.T) {
+	t.Parallel()
 
-	forbiddenRoles := []string{iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.Notification}
-
-	endpoints := []struct {
+	var endpoints = []struct {
 		name   string
 		method string
 		path   string
@@ -52,31 +52,39 @@ func TestTeamsController_ForbiddenRoles(t *testing.T) {
 		{"Check teams channel", http.MethodPost, "/notification-channel/teams/check"},
 	}
 
-	for _, role := range forbiddenRoles {
+	tests := []struct {
+		role      string
+		wantAllow bool
+	}{
+		// ensure this is the same as in iam/roles.go
+		{iam.OsiViewer, false},
+		{iam.User, false},
+		{iam.OsiUser, false},
+		{iam.OsiAdmin, false},
+		{iam.Admin, true},
+		{iam.NotificationAdmin, true},
+		{iam.Notification, false},
+	}
+
+	for _, tt := range tests {
 		for _, ep := range endpoints {
-			t.Run(ep.name+" is forbidden for role "+role, func(t *testing.T) {
-				httpassert.New(t, router).
-					Perform(ep.method, ep.path).
-					AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-					Expect().
-					StatusCode(http.StatusForbidden)
+			t.Run(ep.name+" as "+tt.role, func(t *testing.T) {
+				t.Parallel()
+
+				router := setupWithAuth(t)
+
+				req, _ := http.NewRequest(ep.method, ep.path, nil)
+				req.Header.Set("Authorization", "Bearer "+integrationTests.CreateJwtTokenWithRole(tt.role))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				if tt.wantAllow {
+					require.NotEqual(t, http.StatusUnauthorized, w.Code)
+					require.NotEqual(t, http.StatusForbidden, w.Code)
+				} else {
+					require.Equal(t, http.StatusForbidden, w.Code)
+				}
 			})
 		}
-	}
-}
-
-func TestTeamsController_AllowedRoles(t *testing.T) {
-	router := setup(t)
-
-	allowedRoles := []string{iam.Admin, iam.NotificationAdmin}
-
-	for _, role := range allowedRoles {
-		t.Run("Access is granted for role "+role, func(t *testing.T) {
-			httpassert.New(t, router).
-				Get(`/notification-channel/teams`).
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(role)).
-				Expect().
-				StatusCode(http.StatusOK)
-		})
 	}
 }

--- a/pkg/web/testhelper/testWebEngine.go
+++ b/pkg/web/testhelper/testWebEngine.go
@@ -1,8 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG <https://greenbone.net>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package testhelper
 
 import (
 	"github.com/gin-gonic/gin"
-	logsMiddleware "github.com/greenbone/opensight-golang-libraries/pkg/logs/ginMiddleware"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
 	"github.com/greenbone/opensight-notification-service/pkg/web/middleware"
 )
@@ -12,7 +15,6 @@ func NewTestWebEngine(registry *errmap.Registry) *gin.Engine {
 
 	ginWebEngine := gin.New()
 	ginWebEngine.Use(
-		logsMiddleware.Logging(),
 		gin.Recovery(),
 		middleware.CORS([]string{
 			"http://example.com",


### PR DESCRIPTION
## What
Allow all new roles to endpoints and keep old ones for backward compatibility.
Also modify tests to check for all permission roles to work as intended.

## Why
New roles required for the new keycloak changes.

## References
- First PR [merged]: https://github.com/greenbone/opensight-notification-service/pull/217
- Ticket https://jira.greenbone.net/browse/ARTOSI-350
- Confluence page for permissions: https://confluence.greenbone.net/spaces/SIP/pages/220924838/Permissions+System+for+OSI+-+V2

## Checklist
- [ ] Tests
- [ ] Permissions set correctly