### PR TITLE
fix: give role `osi.admin` permissions for all settings related endpoints

### DIFF
--- a/pkg/web/mailcontroller/checkMailServer.go
+++ b/pkg/web/mailcontroller/checkMailServer.go
@@ -29,7 +29,7 @@ func AddCheckMailServerController(
 	}
 
 	group := router.Group("/notification-channel/mail").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
 
 	group.POST("/check", ctrl.CheckMailServer)
 

--- a/pkg/web/mailcontroller/checkMailServer_test.go
+++ b/pkg/web/mailcontroller/checkMailServer_test.go
@@ -163,7 +163,7 @@ func TestCheckMailServer_Permissions(t *testing.T) {
 		{iam.OsiViewer, false},
 		{iam.User, false},
 		{iam.OsiUser, false},
-		{iam.OsiAdmin, false},
+		{iam.OsiAdmin, true},
 		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},

--- a/pkg/web/mailcontroller/mailController.go
+++ b/pkg/web/mailcontroller/mailController.go
@@ -56,7 +56,7 @@ func (mc *MailController) configureMappings(r errmap.ErrorRegistry) {
 
 func (mc *MailController) registerRoutes(router gin.IRouter, auth gin.HandlerFunc) {
 	group := router.Group("/notification-channel/mail").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.POST("", mc.CreateMailChannel)
 	group.GET("", mc.ListMailChannelsByType)
 	group.PUT("/:id", mc.UpdateMailChannel)

--- a/pkg/web/mailcontroller/mailController_test.go
+++ b/pkg/web/mailcontroller/mailController_test.go
@@ -374,7 +374,7 @@ func TestMailController_Permissions(t *testing.T) {
 		{iam.OsiViewer, false},
 		{iam.User, false},
 		{iam.OsiUser, false},
-		{iam.OsiAdmin, false},
+		{iam.OsiAdmin, true},
 		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},

--- a/pkg/web/mattermostcontroller/mattermostController.go
+++ b/pkg/web/mattermostcontroller/mattermostController.go
@@ -34,7 +34,7 @@ func NewMattermostController(
 	}
 
 	group := router.Group("/notification-channel/mattermost").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.Use(errorHandler(gin.ErrorTypePrivate))
 
 	group.POST("", ctrl.createMattermostChannel)

--- a/pkg/web/mattermostcontroller/mattermostController_test.go
+++ b/pkg/web/mattermostcontroller/mattermostController_test.go
@@ -60,7 +60,7 @@ func TestMattermostController_Permissions(t *testing.T) {
 		{iam.OsiViewer, false},
 		{iam.User, false},
 		{iam.OsiUser, false},
-		{iam.OsiAdmin, false},
+		{iam.OsiAdmin, true},
 		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},

--- a/pkg/web/rulecontroller/ruleController.go
+++ b/pkg/web/rulecontroller/ruleController.go
@@ -53,7 +53,7 @@ func NewRuleController(
 
 func (c *RuleController) RegisterRoutes(router gin.IRouter, auth gin.HandlerFunc) {
 	group := router.Group("/rules").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.GET("/:id", c.GetRule)
 	group.POST("", c.CreateRule)
 	group.PUT("/:id", c.UpdateRule)

--- a/pkg/web/rulecontroller/ruleController_test.go
+++ b/pkg/web/rulecontroller/ruleController_test.go
@@ -62,7 +62,7 @@ func TestRuleController_Permissions(t *testing.T) {
 		{iam.OsiViewer, false},
 		{iam.User, false},
 		{iam.OsiUser, false},
-		{iam.OsiAdmin, false},
+		{iam.OsiAdmin, true},
 		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},

--- a/pkg/web/teamscontroller/teamsController.go
+++ b/pkg/web/teamscontroller/teamsController.go
@@ -35,7 +35,7 @@ func NewTeamsController(
 	}
 
 	group := router.Group("/notification-channel/teams").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.Use(errorHandler(gin.ErrorTypePrivate))
 
 	group.POST("", ctrl.CreateTeamsChannel)

--- a/pkg/web/teamscontroller/teamsController_test.go
+++ b/pkg/web/teamscontroller/teamsController_test.go
@@ -60,7 +60,7 @@ func TestTeamsController_Permissions(t *testing.T) {
 		{iam.OsiViewer, false},
 		{iam.User, false},
 		{iam.OsiUser, false},
-		{iam.OsiAdmin, false},
+		{iam.OsiAdmin, true},
 		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},


### PR DESCRIPTION
## What

fix: give role `osi.admin` permissions for all settings related endpoints

## Why

Missed the entry `can perform any setting actions, except User Management` in the concept page previously.
However has no effect in our current usage, as we don't have yet a user which is `osi.admin` but not `notification.admin`.

## References

ARTOSI-350

## Checklist

- [ ] Tests


