### PR TITLE
Ops: Make sure dependency updates are considered for release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
       time: "04:00"
+    commit-message:
+      prefix: "Deps"
     open-pull-requests-limit: 10
     groups:
       go-modules:
@@ -31,3 +33,5 @@ updates:
       interval: "weekly"
       time: "04:00"
       day: "monday"
+    commit-message:
+      prefix: "Deps"


### PR DESCRIPTION
## What

Prefix dependency update commit messages with 

## Why

Ensures that dependency updates appear in release notes.