### PR TITLE
remove: remove obsolete nested roles `user` and `admin`

### DIFF
--- a/pkg/web/iam/roles.go
+++ b/pkg/web/iam/roles.go
@@ -6,9 +6,7 @@ package iam
 
 const (
 	OsiViewer         = "osi.viewer"
-	User              = "user" // Stays to ensure backwards compatibility
 	OsiUser           = "osi.user"
-	Admin             = "admin" // Stays to ensure backwards compatibility
 	OsiAdmin          = "osi.admin"
 	Notification      = "opensight_notification_role" // Only a service user
 	NotificationAdmin = "notification.admin"          // Same as Admin

--- a/pkg/web/integrationTests/testJwtParser.go
+++ b/pkg/web/integrationTests/testJwtParser.go
@@ -8,13 +8,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/greenbone/keycloak-client-golang/auth"
 )
 
-func NewTestJwtParser(t *testing.T) func(
+func NewTestJwtParser() func(
 	ctx context.Context,
 	authorizationHeader string,
 	originHeader string,

--- a/pkg/web/mailcontroller/checkMailServer.go
+++ b/pkg/web/mailcontroller/checkMailServer.go
@@ -29,7 +29,7 @@ func AddCheckMailServerController(
 	}
 
 	group := router.Group("/notification-channel/mail").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.OsiAdmin, iam.NotificationAdmin)...)
 
 	group.POST("/check", ctrl.CheckMailServer)
 

--- a/pkg/web/mailcontroller/checkMailServer_test.go
+++ b/pkg/web/mailcontroller/checkMailServer_test.go
@@ -29,7 +29,7 @@ func setup(t *testing.T) (*gin.Engine, *mocks.MailChannelService) {
 
 	notificationChannelServicer := mocks.NewMailChannelService(t)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	AddCheckMailServerController(engine, notificationChannelServicer, authMiddleware, registry)
@@ -161,10 +161,8 @@ func TestCheckMailServer_Permissions(t *testing.T) {
 	}{
 		// ensure this is the same as in iam/roles.go
 		{iam.OsiViewer, false},
-		{iam.User, false},
 		{iam.OsiUser, false},
 		{iam.OsiAdmin, true},
-		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},
 	}

--- a/pkg/web/mailcontroller/mailController.go
+++ b/pkg/web/mailcontroller/mailController.go
@@ -56,7 +56,7 @@ func (mc *MailController) configureMappings(r errmap.ErrorRegistry) {
 
 func (mc *MailController) registerRoutes(router gin.IRouter, auth gin.HandlerFunc) {
 	group := router.Group("/notification-channel/mail").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.POST("", mc.CreateMailChannel)
 	group.GET("", mc.ListMailChannelsByType)
 	group.PUT("/:id", mc.UpdateMailChannel)

--- a/pkg/web/mailcontroller/mailController_integration_test.go
+++ b/pkg/web/mailcontroller/mailController_integration_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/greenbone/keycloak-client-golang/auth"
 	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
 	"github.com/greenbone/opensight-notification-service/pkg/services/notificationchannelservice"
 	"github.com/greenbone/opensight-notification-service/pkg/web/errmap"
+	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
+	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
@@ -23,12 +26,14 @@ func TestIntegration_MailController_CRUD(t *testing.T) {
 	t.Run("Perform all the CRUD operations", func(t *testing.T) {
 		router, db := setupTestRouter(t)
 		defer func() { _ = db.Close() }()
+		jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 
 		request := httpassert.New(t, router)
 
 		// --- Create ---
 		var mailId string
 		request.Post("/notification-channel/mail").
+			AuthJwt(jwt).
 			JsonContentObject(valid).
 			Expect().
 			StatusCode(http.StatusCreated).
@@ -47,6 +52,7 @@ func TestIntegration_MailController_CRUD(t *testing.T) {
 
 		// --- List ---
 		request.Get("/notification-channel/mail").
+			AuthJwt(jwt).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonPath("$", httpassert.HasSize(1)).
@@ -68,6 +74,7 @@ func TestIntegration_MailController_CRUD(t *testing.T) {
 		newName := "updated"
 		updated.ChannelName = newName
 		request.Put("/notification-channel/mail/"+mailId).
+			AuthJwt(jwt).
 			JsonContentObject(updated).
 			Expect().
 			StatusCode(http.StatusOK).
@@ -85,11 +92,13 @@ func TestIntegration_MailController_CRUD(t *testing.T) {
 
 		// --- Delete ---
 		request.Delete("/notification-channel/mail/" + mailId).
+			AuthJwt(jwt).
 			Expect().
 			StatusCode(http.StatusNoContent)
 
 		// --- List after delete ---
 		request.Get("/notification-channel/mail").
+			AuthJwt(jwt).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonPath("$", httpassert.HasSize(0))
@@ -98,12 +107,14 @@ func TestIntegration_MailController_CRUD(t *testing.T) {
 	t.Run("Update password with Update Mail", func(t *testing.T) {
 		router, db := setupTestRouter(t)
 		defer db.Close()
+		jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 
 		request := httpassert.New(t, router)
 		var mailId string
 
 		// --- Create ---
 		request.Post("/notification-channel/mail").
+			AuthJwt(jwt).
 			JsonContentObject(valid).
 			Expect().
 			StatusCode(http.StatusCreated).
@@ -132,6 +143,7 @@ func TestIntegration_MailController_CRUD(t *testing.T) {
 		newName := "updated"
 		updated.ChannelName = newName
 		request.Put("/notification-channel/mail/"+mailId).
+			AuthJwt(jwt).
 			JsonContentObject(updated).
 			Expect().
 			StatusCode(http.StatusOK).
@@ -162,8 +174,10 @@ func setupTestRouter(t *testing.T) (*gin.Engine, *sqlx.DB) {
 
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
+	require.NoError(t, err)
 
-	NewMailController(router, svc, mailSvc, testhelper.MockAuthMiddlewareWithAdmin, registry)
+	NewMailController(router, svc, mailSvc, authMiddleware, registry)
 
 	return router, db
 }

--- a/pkg/web/mailcontroller/mailController_test.go
+++ b/pkg/web/mailcontroller/mailController_test.go
@@ -41,11 +41,13 @@ func getValidNotificationChannel() models.NotificationChannel {
 	}
 }
 
-func setupRouter(service *mocks.NotificationChannelService, mailService *mocks.MailChannelService) *gin.Engine {
+func setupRouter(t *testing.T, service *mocks.NotificationChannelService, mailService *mocks.MailChannelService) *gin.Engine {
 	registry := errmap.NewRegistry()
 	engine := testhelper.NewTestWebEngine(registry)
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
+	require.NoError(t, err)
 
-	NewMailController(engine, service, mailService, testhelper.MockAuthMiddlewareWithAdmin, registry)
+	NewMailController(engine, service, mailService, authMiddleware, registry)
 	return engine
 }
 
@@ -96,9 +98,10 @@ func TestMailController_CreateMailChannel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 			mockService := mocks.NewNotificationChannelService(t)
 			mockMailService := mocks.NewMailChannelService(t)
-			router := setupRouter(mockService, mockMailService)
+			router := setupRouter(t, mockService, mockMailService)
 
 			if tt.wantStatusCode == http.StatusCreated || tt.wantStatusCode == http.StatusInternalServerError {
 				mockMailService.On("CreateMailChannel", mock.Anything, mock.Anything).
@@ -106,7 +109,7 @@ func TestMailController_CreateMailChannel(t *testing.T) {
 					Once()
 			}
 
-			req := httpassert.New(t, router).Post("/notification-channel/mail")
+			req := httpassert.New(t, router).Post("/notification-channel/mail").AuthJwt(jwt)
 			if tt.input != nil {
 				req.JsonContentObject(tt.input)
 			}
@@ -174,14 +177,15 @@ func TestMailController_ListMailChannelsByType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 			mockService := mocks.NewNotificationChannelService(t)
-			router := setupRouter(mockService, nil)
+			router := setupRouter(t, mockService, nil)
 
 			mockService.On("ListNotificationChannelsByType", mock.Anything, tt.queryType).
 				Return(tt.mockReturn, tt.mockErr).
 				Once()
 
-			req := httpassert.New(t, router).Get("/notification-channel/mail")
+			req := httpassert.New(t, router).Get("/notification-channel/mail").AuthJwt(jwt)
 			resp := req.Expect()
 			resp.StatusCode(tt.wantStatusCode)
 			if tt.wantStatusCode == http.StatusOK {
@@ -244,16 +248,17 @@ func TestMailController_UpdateMailChannel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 			mockService := mocks.NewNotificationChannelService(t)
 			mockMailService := mocks.NewMailChannelService(t)
-			router := setupRouter(mockService, mockMailService)
+			router := setupRouter(t, mockService, mockMailService)
 
 			if tt.wantStatusCode == http.StatusOK || tt.wantStatusCode == http.StatusInternalServerError {
 				mockService.On("UpdateNotificationChannel", mock.Anything, tt.id, mock.Anything).
 					Return(tt.mockReturn, tt.mockErr).
 					Once()
 			}
-			req := httpassert.New(t, router).Put("/notification-channel/mail/" + tt.id)
+			req := httpassert.New(t, router).Put("/notification-channel/mail/" + tt.id).AuthJwt(jwt)
 			if tt.input != nil {
 				req.JsonContentObject(tt.input)
 			}
@@ -308,14 +313,15 @@ func TestMailController_DeleteMailChannel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 			mockService := mocks.NewNotificationChannelService(t)
-			router := setupRouter(mockService, nil)
+			router := setupRouter(t, mockService, nil)
 
 			mockService.On("DeleteNotificationChannel", mock.Anything, tt.id).
 				Return(tt.mockErr).
 				Once()
 
-			req := httpassert.New(t, router).Delete("/notification-channel/mail/" + tt.id)
+			req := httpassert.New(t, router).Delete("/notification-channel/mail/" + tt.id).AuthJwt(jwt)
 			resp := req.Expect()
 			resp.StatusCode(tt.wantStatusCode)
 			if tt.wantStatusCode == http.StatusNoContent {
@@ -341,7 +347,7 @@ func setupWithAuth(t *testing.T) *gin.Engine {
 	notificationChannelService := mocks.NewNotificationChannelService(t)
 	mailChannelService := mocks.NewMailChannelService(t)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	notificationChannelService.EXPECT().ListNotificationChannelsByType(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
@@ -372,10 +378,8 @@ func TestMailController_Permissions(t *testing.T) {
 	}{
 		// ensure this is the same as in iam/roles.go
 		{iam.OsiViewer, false},
-		{iam.User, false},
 		{iam.OsiUser, false},
 		{iam.OsiAdmin, true},
-		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},
 	}

--- a/pkg/web/mailcontroller/negative_usecases_test.go
+++ b/pkg/web/mailcontroller/negative_usecases_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/greenbone/opensight-golang-libraries/pkg/httpassert"
+	"github.com/greenbone/opensight-notification-service/pkg/web/iam"
+	"github.com/greenbone/opensight-notification-service/pkg/web/integrationTests"
 	"github.com/greenbone/opensight-notification-service/pkg/web/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,12 +21,14 @@ func TestIntegration_MailController_Negative_Cases(t *testing.T) {
 	t.Run("Check if Create/List/Update Mail Notification doesnt return password", func(t *testing.T) {
 		router, db := setupTestRouter(t)
 		defer db.Close()
+		jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 
 		request := httpassert.New(t, router)
 
 		var mailId string
 		// --- Create ---
 		createBody := request.Post("/notification-channel/mail").
+			AuthJwt(jwt).
 			JsonContentObject(valid).
 			Expect().
 			StatusCode(http.StatusCreated).
@@ -36,6 +40,7 @@ func TestIntegration_MailController_Negative_Cases(t *testing.T) {
 
 		// --- List ---
 		listBody := request.Get("/notification-channel/mail").
+			AuthJwt(jwt).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonPath("$", httpassert.HasSize(1)).
@@ -48,6 +53,7 @@ func TestIntegration_MailController_Negative_Cases(t *testing.T) {
 		newName := "updated"
 		updated.ChannelName = newName
 		updateBody := request.Put("/notification-channel/mail/"+mailId).
+			AuthJwt(jwt).
 			JsonContentObject(updated).
 			Expect().
 			StatusCode(http.StatusOK).
@@ -60,12 +66,14 @@ func TestIntegration_MailController_Negative_Cases(t *testing.T) {
 	t.Run("Do not update password in Update Mail if it passed as nil", func(t *testing.T) {
 		router, db := setupTestRouter(t)
 		defer db.Close()
+		jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 
 		request := httpassert.New(t, router)
 		var mailId string
 
 		// --- Create ---
 		request.Post("/notification-channel/mail").
+			AuthJwt(jwt).
 			JsonContentObject(valid).
 			Expect().
 			StatusCode(http.StatusCreated).
@@ -84,6 +92,7 @@ func TestIntegration_MailController_Negative_Cases(t *testing.T) {
 		newName := "updated"
 		updated.ChannelName = newName
 		request.Put("/notification-channel/mail/"+mailId).
+			AuthJwt(jwt).
 			JsonContentObject(updated).
 			Expect().
 			StatusCode(http.StatusOK).
@@ -99,12 +108,14 @@ func TestIntegration_MailController_Negative_Cases(t *testing.T) {
 	t.Run("Creating two Mail configs with same name", func(t *testing.T) {
 		router, db := setupTestRouter(t)
 		defer db.Close()
+		jwt := integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)
 
 		request := httpassert.New(t, router)
 		var mailId string
 
 		// --- Create ---
 		request.Post("/notification-channel/mail").
+			AuthJwt(jwt).
 			JsonContentObject(valid).
 			Expect().
 			StatusCode(http.StatusCreated).
@@ -112,6 +123,7 @@ func TestIntegration_MailController_Negative_Cases(t *testing.T) {
 		require.NotEmpty(t, mailId)
 
 		request.Post("/notification-channel/mail").
+			AuthJwt(jwt).
 			JsonContentObject(valid).
 			Expect().
 			StatusCode(http.StatusUnprocessableEntity)

--- a/pkg/web/mattermostcontroller/mattermostController.go
+++ b/pkg/web/mattermostcontroller/mattermostController.go
@@ -34,7 +34,7 @@ func NewMattermostController(
 	}
 
 	group := router.Group("/notification-channel/mattermost").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.Use(errorHandler(gin.ErrorTypePrivate))
 
 	group.POST("", ctrl.createMattermostChannel)

--- a/pkg/web/mattermostcontroller/mattermostController_test.go
+++ b/pkg/web/mattermostcontroller/mattermostController_test.go
@@ -27,7 +27,7 @@ func setupWithAuth(t *testing.T) *gin.Engine {
 	notificationChannelService := mocks.NewNotificationChannelService(t)
 	mattermostChannelService := mocks.NewMattermostChannelService(t)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	notificationChannelService.EXPECT().ListNotificationChannelsByType(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
@@ -58,10 +58,8 @@ func TestMattermostController_Permissions(t *testing.T) {
 	}{
 		// ensure this is the same as in iam/roles.go
 		{iam.OsiViewer, false},
-		{iam.User, false},
 		{iam.OsiUser, false},
 		{iam.OsiAdmin, true},
-		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},
 	}

--- a/pkg/web/mattermostcontroller/useCases/checkMattermostChannel_test.go
+++ b/pkg/web/mattermostcontroller/useCases/checkMattermostChannel_test.go
@@ -32,7 +32,7 @@ func setup(t *testing.T, transport http.Client) *gin.Engine {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	mattermostcontroller.NewMattermostController(router, svc, mattermostChannelSvc, authMiddleware, registry)
@@ -57,7 +57,7 @@ func TestCheckMattermostChannel(t *testing.T) {
 
 		// Check mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"webhookUrl": "https://example.com/hooks/id1"
 			}`).
@@ -81,7 +81,7 @@ func TestCheckMattermostChannel(t *testing.T) {
 
 		// Check mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"webhookUrl": "invalid"
 			}`).
@@ -113,7 +113,7 @@ func TestCheckMattermostChannel(t *testing.T) {
 
 		// Check mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"webhookUrl": "https://example.com/hooks/id1"
 			}`).
@@ -142,7 +142,7 @@ func TestCheckMattermostChannel(t *testing.T) {
 
 		// Check mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`).
 			Expect().
 			StatusCode(http.StatusBadRequest).

--- a/pkg/web/mattermostcontroller/useCases/createMattermostChannel_test.go
+++ b/pkg/web/mattermostcontroller/useCases/createMattermostChannel_test.go
@@ -21,7 +21,7 @@ func TestCreateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -49,7 +49,7 @@ func TestCreateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "a",
 				"webhookUrl": "invalid",
@@ -74,7 +74,7 @@ func TestCreateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`).
 			Expect().
 			StatusCode(http.StatusBadRequest).
@@ -96,7 +96,7 @@ func TestCreateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost 1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -107,7 +107,7 @@ func TestCreateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel with the same name
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost 1",
 				"webhookUrl": "https://example.com/hooks/id1",

--- a/pkg/web/mattermostcontroller/useCases/deleteMattermostChannel_test.go
+++ b/pkg/web/mattermostcontroller/useCases/deleteMattermostChannel_test.go
@@ -26,7 +26,7 @@ func setupTestRouter(t *testing.T) (*gin.Engine, *sqlx.DB) {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	mattermostcontroller.NewMattermostController(router, svc, mattermostSvc, authMiddleware, registry)
@@ -45,7 +45,7 @@ func TestDeleteMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -66,7 +66,7 @@ func TestDeleteMattermostChannel(t *testing.T) {
 
 		// Delete mattermost channel
 		httpassert.New(t, router).Deletef("/notification-channel/mattermost/%s", mattermostId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusNoContent)
 	})

--- a/pkg/web/mattermostcontroller/useCases/listMattermostChannels_test.go
+++ b/pkg/web/mattermostcontroller/useCases/listMattermostChannels_test.go
@@ -21,7 +21,7 @@ func TestListMattermostChannels(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -42,7 +42,7 @@ func TestListMattermostChannels(t *testing.T) {
 
 		// List mattermost channels
 		httpassert.New(t, router).Get("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonTemplate(`[

--- a/pkg/web/mattermostcontroller/useCases/updateMattermostChannel_test.go
+++ b/pkg/web/mattermostcontroller/useCases/updateMattermostChannel_test.go
@@ -21,7 +21,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -34,7 +34,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Update mattermost channel
 		httpassert.New(t, router).Putf("/notification-channel/mattermost/%s", mattermostId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost2",
 				"webhookUrl": "https://example.com/hooks/id2",
@@ -62,7 +62,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -75,7 +75,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Update mattermost channel
 		httpassert.New(t, router).Putf("/notification-channel/mattermost/%s", mattermostId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "1",
 				"webhookUrl": "invalid",
@@ -102,7 +102,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -115,7 +115,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Update mattermost channel
 		httpassert.New(t, router).Putf("/notification-channel/mattermost/%s", mattermostId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`).
 			Expect().
 			StatusCode(http.StatusBadRequest).
@@ -139,7 +139,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost 1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -150,7 +150,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Create mattermost channel
 		httpassert.New(t, router).Post("/notification-channel/mattermost").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost 2",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -163,7 +163,7 @@ func TestUpdateMattermostChannel(t *testing.T) {
 
 		// Update mattermost channel
 		httpassert.New(t, router).Putf("/notification-channel/mattermost/%s", mattermostId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "mattermost 1",
 				"webhookUrl": "https://example.com/hooks/id1",

--- a/pkg/web/notificationcontroller/notificationController.go
+++ b/pkg/web/notificationcontroller/notificationController.go
@@ -35,7 +35,7 @@ func AddNotificationController(
 
 	groupPath := "/notifications"
 
-	router.Group(groupPath).Use(middleware.AuthorizeRoles(auth, iam.OsiViewer, iam.User, iam.OsiUser, iam.OsiAdmin, iam.NotificationAdmin)...).
+	router.Group(groupPath).Use(middleware.AuthorizeRoles(auth, iam.OsiViewer, iam.OsiUser, iam.OsiAdmin, iam.NotificationAdmin)...).
 		PUT("", ctrl.ListNotifications).
 		GET("/options", ctrl.GetOptions)
 	// only to be used by other backend services

--- a/pkg/web/notificationcontroller/notificationController_test.go
+++ b/pkg/web/notificationcontroller/notificationController_test.go
@@ -46,7 +46,7 @@ func setup(t *testing.T) (*gin.Engine, *mocks.NotificationService) {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 	mockNotificationService := mocks.NewNotificationService(t)
 	AddNotificationController(router, mockNotificationService, authMiddleware)
@@ -70,10 +70,8 @@ func TestCreateNotification_Permissions(t *testing.T) {
 		wantAllow bool
 	}{
 		{iam.OsiViewer, false},
-		{iam.User, false},
 		{iam.OsiUser, false},
 		{iam.OsiAdmin, false},
-		{iam.Admin, false},
 		{iam.NotificationAdmin, false},
 		{iam.Notification, true},
 	}
@@ -181,7 +179,7 @@ func TestListNotifications(t *testing.T) {
 
 			var gotResponse query.ResponseListWithMetadata[models.Notification]
 			httpassert.New(t, router).Put("/notifications").
-				AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.User)).
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.OsiUser)).
 				JsonContentObject(tt.requestBody).
 				Expect().
 				StatusCode(tt.want.responseCode).
@@ -209,10 +207,8 @@ func TestListNotifications_Permissions(t *testing.T) {
 	}{
 		// ensure this is the same as in iam/roles.go
 		{iam.OsiViewer, true},
-		{iam.User, true},
 		{iam.OsiUser, true},
 		{iam.OsiAdmin, true},
-		{iam.Admin, false},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},
 	}

--- a/pkg/web/notificationcontroller/useCases/forward_notification_test.go
+++ b/pkg/web/notificationcontroller/useCases/forward_notification_test.go
@@ -77,7 +77,7 @@ func setup(t *testing.T) (
 
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	mailcontroller.NewMailController(router, channelService, mailChannelService, authMiddleware, registry)
@@ -106,7 +106,7 @@ func TestForwardNotification(t *testing.T) {
 	httpassert.New(t, router).
 		Post("/notification-channel/mail").
 		JsonContentObject(mailChannel).
-		AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+		AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 		Expect().
 		StatusCode(http.StatusCreated).
 		JsonPath("$.id", httpassert.ExtractTo(&mailChannelID))
@@ -135,7 +135,7 @@ func TestForwardNotification(t *testing.T) {
 				"active": true
 			}`, models.OriginAllClass, mailChannelID),
 		).
-		AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+		AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 		Expect().
 		StatusCode(http.StatusCreated).
 		JsonPath("$.id", httpassert.ExtractTo(&ruleID))

--- a/pkg/web/origincontroller/originController_test.go
+++ b/pkg/web/origincontroller/originController_test.go
@@ -117,11 +117,15 @@ func TestRegisterOrigins(t *testing.T) {
 			registry := errmap.NewRegistry()
 			router := testhelper.NewTestWebEngine(registry)
 
-			_ = NewOriginController(router, mockService, testhelper.MockAuthMiddlewareWithNotificationUser)
+			authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
+			require.NoError(t, err)
+
+			_ = NewOriginController(router, mockService, authMiddleware)
 
 			request := httpassert.New(t, router)
 
 			resp := request.Put("/origins/" + tt.serviceID).
+				AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Notification)).
 				JsonContentObject(tt.origins).
 				Expect().
 				StatusCode(tt.wantResponseCode)
@@ -137,7 +141,7 @@ func setupWithAuth(t *testing.T) *gin.Engine {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	NewOriginController(router, mockService, authMiddleware)
@@ -161,10 +165,8 @@ func TestRegisterOrigins_Permissions(t *testing.T) {
 	}{
 		// ensure this is the same as in iam/roles.go
 		{iam.OsiViewer, false},
-		{iam.User, false},
 		{iam.OsiUser, false},
 		{iam.OsiAdmin, false},
-		{iam.Admin, false},
 		{iam.NotificationAdmin, false},
 		{iam.Notification, true},
 	}

--- a/pkg/web/rulecontroller/ruleController.go
+++ b/pkg/web/rulecontroller/ruleController.go
@@ -53,7 +53,7 @@ func NewRuleController(
 
 func (c *RuleController) RegisterRoutes(router gin.IRouter, auth gin.HandlerFunc) {
 	group := router.Group("/rules").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.GET("/:id", c.GetRule)
 	group.POST("", c.CreateRule)
 	group.PUT("/:id", c.UpdateRule)

--- a/pkg/web/rulecontroller/ruleController_test.go
+++ b/pkg/web/rulecontroller/ruleController_test.go
@@ -26,7 +26,7 @@ func setupWithAuth(t *testing.T) *gin.Engine {
 	router := testhelper.NewTestWebEngine(registry)
 	ruleService := mocks.NewRuleService(t)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	ruleService.EXPECT().List(mock.Anything).Maybe().Return([]models.Rule{}, nil)
@@ -60,10 +60,8 @@ func TestRuleController_Permissions(t *testing.T) {
 	}{
 		// ensure this is the same as in iam/roles.go
 		{iam.OsiViewer, false},
-		{iam.User, false},
 		{iam.OsiUser, false},
 		{iam.OsiAdmin, true},
-		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},
 	}

--- a/pkg/web/rulecontroller/usecases/createRule_test.go
+++ b/pkg/web/rulecontroller/usecases/createRule_test.go
@@ -72,7 +72,7 @@ func setupTestEnvironmentWithRepoReturn(t *testing.T, origins []entities.Origin,
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	rulecontroller.NewRuleController(router, ruleService, authMiddleware, registry)
@@ -91,7 +91,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, origins, channels, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -150,7 +150,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, nil, nil, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`).
 			Expect().
 			StatusCode(http.StatusBadRequest).
@@ -172,7 +172,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, nil, nil, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"trigger": {
 					"origins": [{}],
@@ -206,7 +206,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, origins, channels, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -239,7 +239,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, origins, channels, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -271,7 +271,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, nil, channels, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -302,7 +302,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, origins, nil, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -334,7 +334,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, origins, channels, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -351,7 +351,7 @@ func Test_CreateRule(t *testing.T) {
 			StatusCode(http.StatusCreated)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -383,7 +383,7 @@ func Test_CreateRule(t *testing.T) {
 		router := setupTestEnvironment(t, origins, channels, ruleLimit)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				"trigger": {
@@ -400,7 +400,7 @@ func Test_CreateRule(t *testing.T) {
 			StatusCode(http.StatusCreated)
 
 		httpassert.New(t, router).Post("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule 2",
 				"trigger": {

--- a/pkg/web/rulecontroller/usecases/deleteRule_test.go
+++ b/pkg/web/rulecontroller/usecases/deleteRule_test.go
@@ -45,13 +45,13 @@ func Test_DeleteRule(t *testing.T) {
 			}`, channels[0].Id))
 
 		httpassert.New(t, router).Deletef("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusNoContent)
 
 		// verify rule is deleted
 		httpassert.New(t, router).Getf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusNotFound)
 	})
@@ -61,7 +61,7 @@ func Test_DeleteRule(t *testing.T) {
 		router := setupTestEnvironment(t, nil, nil, 10)
 
 		httpassert.New(t, router).Deletef("/rules/%s", uuid.NewString()).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusNoContent)
 	})
@@ -72,7 +72,7 @@ func Test_DeleteRule(t *testing.T) {
 		router := setupTestEnvironment(t, nil, nil, ruleLimit)
 
 		httpassert.New(t, router).Get("/rules/invalid-uuid").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusBadRequest).
 			Json(`{

--- a/pkg/web/rulecontroller/usecases/getRule_test.go
+++ b/pkg/web/rulecontroller/usecases/getRule_test.go
@@ -52,7 +52,7 @@ func Test_GetRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Getf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonPath("$.id", httpassert.NotEmpty()).
@@ -114,7 +114,7 @@ func Test_GetRule(t *testing.T) {
 		require.NoError(t, err)
 
 		httpassert.New(t, router).Getf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonPath("$.id", httpassert.IsUUID()).
@@ -150,7 +150,7 @@ func Test_GetRule(t *testing.T) {
 		router := setupTestEnvironment(t, nil, nil, ruleLimit)
 
 		httpassert.New(t, router).Getf("/rules/%s", uuid.NewString()).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusNotFound)
 	})
@@ -161,7 +161,7 @@ func Test_GetRule(t *testing.T) {
 		router := setupTestEnvironment(t, nil, nil, ruleLimit)
 
 		httpassert.New(t, router).Get("/rules/invalid-uuid").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusBadRequest).
 			Json(`{

--- a/pkg/web/rulecontroller/usecases/listRules_test.go
+++ b/pkg/web/rulecontroller/usecases/listRules_test.go
@@ -27,7 +27,7 @@ func Test_ListRules(t *testing.T) {
 		router := setupTestEnvironment(t, nil, nil, ruleLimit)
 
 		httpassert.New(t, router).Get("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusOK).
 			Json("[]")
@@ -63,7 +63,7 @@ func Test_ListRules(t *testing.T) {
 			}`, channels[0].Id))
 
 		httpassert.New(t, router).Get("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonPath("$[0].id", httpassert.NotEmpty()).
@@ -152,7 +152,7 @@ func Test_ListRules(t *testing.T) {
 		require.NoError(t, err)
 
 		httpassert.New(t, router).Get("/rules").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonPath("$[0].id", httpassert.IsUUID()).

--- a/pkg/web/rulecontroller/usecases/updateRule_test.go
+++ b/pkg/web/rulecontroller/usecases/updateRule_test.go
@@ -22,7 +22,7 @@ import (
 
 func createRule(t *testing.T, router *gin.Engine, ruleJSON string) (ruleID string) {
 	httpassert.New(t, router).Post("/rules").
-		AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+		AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 		JsonContent(ruleJSON).
 		Expect().
 		StatusCode(http.StatusCreated).
@@ -59,7 +59,7 @@ func Test_UpdateRule(t *testing.T) {
 			}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Updated Test Rule",
 				"trigger": {
@@ -130,7 +130,7 @@ func Test_UpdateRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`). // missing required fields
 			Expect().
 			StatusCode(http.StatusBadRequest).
@@ -165,7 +165,7 @@ func Test_UpdateRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"trigger": {
 					"levels": [""],
@@ -209,7 +209,7 @@ func Test_UpdateRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule Updated",
 				"trigger": {
@@ -251,7 +251,7 @@ func Test_UpdateRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule Updated",
 				"trigger": {
@@ -293,7 +293,7 @@ func Test_UpdateRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Updated Test Rule",
 				"trigger": {
@@ -334,7 +334,7 @@ func Test_UpdateRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"name": "Updated Test Rule",
 				"trigger": {
@@ -387,7 +387,7 @@ func Test_UpdateRule(t *testing.T) {
 		}`, channels[0].Id))
 
 		httpassert.New(t, router).Putf("/rules/%s", ruleID).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Other Rule",
 				"trigger": {
@@ -417,7 +417,7 @@ func Test_UpdateRule(t *testing.T) {
 		router := setupTestEnvironment(t, origins, channels, ruleLimit)
 
 		httpassert.New(t, router).Putf("/rules/%s", uuid.New().String()).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(fmt.Sprintf(`{
 				"name": "Test Rule",
 				
@@ -455,7 +455,7 @@ func Test_UpdateRule(t *testing.T) {
 		}
 
 		httpassert.New(t, router).Put("/rules/invalid-id").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContentObject(updateRule).
 			Expect().
 			StatusCode(http.StatusBadRequest).

--- a/pkg/web/teamscontroller/teamsController.go
+++ b/pkg/web/teamscontroller/teamsController.go
@@ -35,7 +35,7 @@ func NewTeamsController(
 	}
 
 	group := router.Group("/notification-channel/teams").
-		Use(middleware.AuthorizeRoles(auth, iam.Admin, iam.OsiAdmin, iam.NotificationAdmin)...)
+		Use(middleware.AuthorizeRoles(auth, iam.OsiAdmin, iam.NotificationAdmin)...)
 	group.Use(errorHandler(gin.ErrorTypePrivate))
 
 	group.POST("", ctrl.CreateTeamsChannel)

--- a/pkg/web/teamscontroller/teamsController_test.go
+++ b/pkg/web/teamscontroller/teamsController_test.go
@@ -27,7 +27,7 @@ func setupWithAuth(t *testing.T) *gin.Engine {
 	notificationChannelService := mocks.NewNotificationChannelService(t)
 	teamsChannelService := mocks.NewTeamsChannelService(t)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	notificationChannelService.EXPECT().ListNotificationChannelsByType(mock.Anything, mock.Anything).Maybe().Return(nil, nil)
@@ -58,10 +58,8 @@ func TestTeamsController_Permissions(t *testing.T) {
 	}{
 		// ensure this is the same as in iam/roles.go
 		{iam.OsiViewer, false},
-		{iam.User, false},
 		{iam.OsiUser, false},
 		{iam.OsiAdmin, true},
-		{iam.Admin, true},
 		{iam.NotificationAdmin, true},
 		{iam.Notification, false},
 	}

--- a/pkg/web/teamscontroller/useCases/checkTeamsChannel_test.go
+++ b/pkg/web/teamscontroller/useCases/checkTeamsChannel_test.go
@@ -32,7 +32,7 @@ func setup(t *testing.T, transport http.Client) *gin.Engine {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	teamscontroller.NewTeamsController(router, svc, teamsChannelSvc, authMiddleware, registry)
@@ -57,7 +57,7 @@ func TestCheckTeamsChannel(t *testing.T) {
 
 		// Check teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"webhookUrl": "https://example.com/hooks/id1"
 			}`).
@@ -81,7 +81,7 @@ func TestCheckTeamsChannel(t *testing.T) {
 
 		// Check teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"webhookUrl": "https://example.com/webhook/id1"
 			}`).
@@ -105,7 +105,7 @@ func TestCheckTeamsChannel(t *testing.T) {
 
 		// Check teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"webhookUrl": "invalid"
 			}`).
@@ -137,7 +137,7 @@ func TestCheckTeamsChannel(t *testing.T) {
 
 		// Check teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"webhookUrl": "https://example.com/hooks/id1"
 			}`).
@@ -166,7 +166,7 @@ func TestCheckTeamsChannel(t *testing.T) {
 
 		// Check teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams/check").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`).
 			Expect().
 			StatusCode(http.StatusBadRequest).

--- a/pkg/web/teamscontroller/useCases/createTeamsChannel_test.go
+++ b/pkg/web/teamscontroller/useCases/createTeamsChannel_test.go
@@ -21,7 +21,7 @@ func TestCreateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -49,7 +49,7 @@ func TestCreateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "a",
 				"webhookUrl": "invalid",
@@ -74,7 +74,7 @@ func TestCreateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`).
 			Expect().
 			StatusCode(http.StatusBadRequest).
@@ -96,7 +96,7 @@ func TestCreateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams 1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -107,7 +107,7 @@ func TestCreateTeamsChannel(t *testing.T) {
 
 		// Create teams channel with the same name
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams 1",
 				"webhookUrl": "https://example.com/hooks/id1",

--- a/pkg/web/teamscontroller/useCases/deleteTeamsChannel_test.go
+++ b/pkg/web/teamscontroller/useCases/deleteTeamsChannel_test.go
@@ -26,7 +26,7 @@ func setupTestRouter(t *testing.T) (*gin.Engine, *sqlx.DB) {
 	registry := errmap.NewRegistry()
 	router := testhelper.NewTestWebEngine(registry)
 
-	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser(t))
+	authMiddleware, err := auth.NewGinAuthMiddleware(integrationTests.NewTestJwtParser())
 	require.NoError(t, err)
 
 	teamscontroller.NewTeamsController(router, svc, teamsSvc, authMiddleware, registry)
@@ -45,7 +45,7 @@ func TestDeleteTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -66,7 +66,7 @@ func TestDeleteTeamsChannel(t *testing.T) {
 
 		// Delete teams channel
 		httpassert.New(t, router).Deletef("/notification-channel/teams/%s", teamsId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusNoContent)
 	})

--- a/pkg/web/teamscontroller/useCases/listTeamsChannels_test.go
+++ b/pkg/web/teamscontroller/useCases/listTeamsChannels_test.go
@@ -21,7 +21,7 @@ func TestListTeamsChannels(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -42,7 +42,7 @@ func TestListTeamsChannels(t *testing.T) {
 
 		// List teams channels
 		httpassert.New(t, router).Get("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			Expect().
 			StatusCode(http.StatusOK).
 			JsonTemplate(`[

--- a/pkg/web/teamscontroller/useCases/updateTeamsChannel_test.go
+++ b/pkg/web/teamscontroller/useCases/updateTeamsChannel_test.go
@@ -21,7 +21,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -34,7 +34,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Update teams channel
 		httpassert.New(t, router).Putf("/notification-channel/teams/%s", teamsId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams2",
 				"webhookUrl": "https://example.com/hooks/id2",
@@ -62,7 +62,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -75,7 +75,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Update teams channel
 		httpassert.New(t, router).Putf("/notification-channel/teams/%s", teamsId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "1",
 				"webhookUrl": "invalid",
@@ -102,7 +102,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -115,7 +115,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Update teams channel
 		httpassert.New(t, router).Putf("/notification-channel/teams/%s", teamsId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{}`).
 			Expect().
 			StatusCode(http.StatusBadRequest).
@@ -139,7 +139,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams 1",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -150,7 +150,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Create teams channel
 		httpassert.New(t, router).Post("/notification-channel/teams").
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams 2",
 				"webhookUrl": "https://example.com/hooks/id1",
@@ -163,7 +163,7 @@ func TestUpdateTeamsChannel(t *testing.T) {
 
 		// Update teams channel
 		httpassert.New(t, router).Putf("/notification-channel/teams/%s", teamsId).
-			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.Admin)).
+			AuthJwt(integrationTests.CreateJwtTokenWithRole(iam.NotificationAdmin)).
 			JsonContent(`{
 				"channelName": "teams 1",
 				"webhookUrl": "https://example.com/hooks/id1",

--- a/pkg/web/testhelper/helper.go
+++ b/pkg/web/testhelper/helper.go
@@ -8,8 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
-	"github.com/greenbone/keycloak-client-golang/auth"
 	"github.com/greenbone/opensight-golang-libraries/pkg/errorResponses"
 	"github.com/greenbone/opensight-notification-service/pkg/config"
 	"github.com/greenbone/opensight-notification-service/pkg/helper"
@@ -57,41 +55,6 @@ func NewJSONRequest(method, url string, bodyAsStruct any) (*http.Request, error)
 		return nil, fmt.Errorf("could not parse struct to json: %w", err)
 	}
 	return http.NewRequest(method, url, bytes.NewReader(body))
-}
-
-// MockAuthMiddleware mocks authentication by setting a default user context in the Gin context for testing purposes.
-func MockAuthMiddleware(ctx *gin.Context) {
-	const iamRoleUser = "user"
-	mockAuthMiddlewareWithRole(ctx, iamRoleUser)
-}
-
-// MockAuthMiddleware mocks authentication by setting a admin user context in the Gin context for testing purposes.
-func MockAuthMiddlewareWithAdmin(ctx *gin.Context) {
-	const iamRoleUser = "admin"
-	mockAuthMiddlewareWithRole(ctx, iamRoleUser)
-}
-
-// MockAuthMiddleware mocks authentication by setting a notification user context in the Gin context for testing purposes.
-func MockAuthMiddlewareWithNotificationUser(ctx *gin.Context) {
-	const iamRoleUser = "opensight_notification_role"
-	mockAuthMiddlewareWithRole(ctx, iamRoleUser)
-}
-
-func mockAuthMiddlewareWithRole(ctx *gin.Context, role string) {
-	const userContextKey = "USER_CONTEXT_DATA"
-
-	userContext := auth.UserContext{
-		Realm:          "",
-		UserID:         "",
-		UserName:       "",
-		EmailAddress:   "",
-		Roles:          []string{role},
-		Groups:         nil,
-		AllowedOrigins: nil,
-	}
-
-	ctx.Set(userContextKey, userContext)
-	ctx.Next()
 }
 
 func SetupNotificationChannelTestEnv(t *testing.T) (notificationrepository.NotificationChannelRepository, *sqlx.DB) {


### PR DESCRIPTION
## What

remove: remove obsolete nested roles `user` and `admin`

Also removed old middleware approach which just sets the token and rely on `integrationTests.NewTestJwtParser` and `integrationTests.NewTestJwtParser()`. This is closer to the real production setup and verifies that the used nested role in the token is among the required roles by the respective endpoint.

## Why

They are legacy roles which are no longer to be used for authorization

## References

ARTOSI-535



