### PR TITLE
CI: require test coverage of 80% for touched code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,5 @@ coverage:
         informational: true
     patch:
       default:
-        informational: true
+        target: 80%
+        threshold: 0%


### PR DESCRIPTION
## What

Require test coverage of 80% for touched code

Overall project status stays informational for now.

## Why

Follow new company guideline.

## References

ARTOSI-748